### PR TITLE
Fix NRE in AmqpBodyStreamMessage.BodyStream

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/AmqpMessage.cs
+++ b/Microsoft.Azure.Amqp/Amqp/AmqpMessage.cs
@@ -623,6 +623,7 @@ namespace Microsoft.Azure.Amqp
             {
                 get
                 {
+                    this.EnsureInitialized();
                     return new BufferListStream(this.bodyData);
                 }
 

--- a/test/Test.Microsoft.Amqp/TestCases/AmqpMessageTests.cs
+++ b/test/Test.Microsoft.Amqp/TestCases/AmqpMessageTests.cs
@@ -91,6 +91,16 @@
             return buffers.ToArray();
         }
 
+        [TestMethod()]
+        public void AmqpMessageStreamTest()
+        {
+            AmqpMessage message = AmqpMessage.Create(new MemoryStream(new byte[12]), true);
+            Assert.AreEqual(12, message.BodyStream.Length);
+
+            AmqpMessage message2 = AmqpMessage.Create(new MemoryStream(new byte[12]), false);
+            Assert.AreEqual(12, message2.BodyStream.Length);
+        }
+
         static void AddSection(AmqpMessage message, SectionFlag sections)
         {
             if ((sections & SectionFlag.Header) != 0)


### PR DESCRIPTION
Accessing the `BodyStream` property on an `AmqpBodyStreamMessage` right after construction results in an NRE.

This change ensures that the message is initialized before accessing `this.bodyData`.