### PR TITLE
TestAmqpBroker should only be started and stopped once during tests…

### DIFF
--- a/test/Test.Microsoft.Amqp/Common/TestAmqpBrokerFixture.cs
+++ b/test/Test.Microsoft.Amqp/Common/TestAmqpBrokerFixture.cs
@@ -1,0 +1,27 @@
+namespace Test.Microsoft.Azure.Amqp
+{
+    using System;
+    using TestAmqpBroker;
+    using Xunit;
+
+    public class TestAmqpBrokerFixture : IDisposable
+    {
+        const string address = "amqp://localhost:15672";
+
+        public TestAmqpBrokerFixture()
+        {
+            this.Address = new Uri(address);
+            this.Broker = new TestAmqpBroker(new string[] { address }, "guest:guest", null, null);
+            this.Broker.Start();
+        }
+
+        public Uri Address { get; }
+
+        public TestAmqpBroker Broker { get; }
+
+        public void Dispose()
+        {
+            this.Broker.Stop();
+        }
+    }
+}

--- a/test/Test.Microsoft.Amqp/Test.Microsoft.Azure.Amqp.csproj
+++ b/test/Test.Microsoft.Amqp/Test.Microsoft.Azure.Amqp.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\AmqpUtils.cs" />
+    <Compile Include="Common\TestAmqpBrokerFixture.cs" />
     <Compile Include="Common\TestCategory.cs" />
     <Compile Include="Common\Person.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/Test.Microsoft.Amqp/TestCases/AmqpLinkTests.cs
+++ b/test/Test.Microsoft.Amqp/TestCases/AmqpLinkTests.cs
@@ -16,22 +16,15 @@
     using Xunit;
 
     [Trait("Category", TestCategory.Current)]
-    public class AmqpLinkTests : IDisposable
+    public class AmqpLinkTests : IClassFixture<TestAmqpBrokerFixture>
     {
-        const string address = "amqp://localhost:15672";
         Uri addressUri;
         TestAmqpBroker broker;
 
-        public AmqpLinkTests()
+        public AmqpLinkTests(TestAmqpBrokerFixture testAmqpBrokerFixture)
         {
-            addressUri = new Uri(address);
-            broker = new TestAmqpBroker(new string[] { address }, "guest:guest", null, null);
-            broker.Start();
-        }
-
-        public void Dispose()
-        {
-            broker.Stop();
+            addressUri = testAmqpBrokerFixture.Address;            
+            broker = testAmqpBrokerFixture.Broker;
         }
 
         [Fact]


### PR DESCRIPTION
Listening upon, closing, then attempting to listen upon the same socket is throwing in Linux.