### PR TITLE
A couple of updates to the make_nuget_package.ps1 script.

### DIFF
--- a/Microsoft.Azure.Amqp/Nuget/make_nuget_package.ps1
+++ b/Microsoft.Azure.Amqp/Nuget/make_nuget_package.ps1
@@ -12,17 +12,19 @@ function GetAssemblyVersionFromFile($filename) {
 }
 
 if (-Not (Test-Path 'NuGet.exe')) {
-    Invoke-WebRequest 'https://nuget.org/nuget.exe' -OutFile 'NuGet.exe'
+    Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile 'NuGet.exe'
 }
 
-$dotNetFile = "..\Properties\AssemblyInfo.cs"
+$PSScriptRoot = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+$AssemblyInfoFile = "$PSScriptRoot\..\Properties\AssemblyInfo.cs"
+$BuildConfig = "Release"
+$OutputDirectory = [IO.Path]::GetFullPath("$PSScriptRoot\..\..\bin\$BuildConfig\")
 
 # Delete existing packages to force rebuild
-ls Microsoft.Azure.Amqp.*.nupkg | % { del $_ }
+ls "$OutputDirectory\Microsoft.Azure.Amqp.*.nupkg" | % { del $_ }
 
-$v1 = GetAssemblyVersionFromFile($dotNetFile)
+$ver = GetAssemblyVersionFromFile($AssemblyInfoFile)
 $id='Microsoft.Azure.Amqp'
 
-echo "Creating NuGet package $id version $v1"
-
-.\NuGet.exe pack "$id.nuspec" -Prop Configuration=Release -Prop Version=$v1
+echo "Creating NuGet package $id version $ver"
+.\NuGet.exe pack "$PSScriptRoot\$id.nuspec" -Prop Configuration=$BuildConfig -Prop Version=$ver -OutputDirectory $OutputDirectory


### PR DESCRIPTION
- Make it possible to run the "make_nuget_package.ps1" script from any location, instead of having to "cd Microsoft.Azure.Amqp\Nuget".
- Move to Nuget.exe version 3.* (from 2.8.6) to avoid the warning about "netstandard1.*" not being a known target.
- Have Nuget.exe build the Microsoft.Azure.Amqp.nupkg into the "%REPOROOT%\bin\Release" folder instead of "%REPOROOT%\Microsoft.Azure.Amqp\Nuget".