### PR TITLE
Adding static flag to include error details

### DIFF
--- a/Microsoft.Azure.Amqp.PCL/Properties/AssemblyInfo.cs
+++ b/Microsoft.Azure.Amqp.PCL/Properties/AssemblyInfo.cs
@@ -26,4 +26,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("2.0.2")]
+[assembly: AssemblyInformationalVersion("2.0.5")]

--- a/Microsoft.Azure.Amqp/Amqp/Framing/Error.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Framing/Error.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Amqp.Framing
     {
         public static readonly string Name = "amqp:error:list";
         public static readonly ulong Code = 0x000000000000001d;
+        public static bool IncludeErrorDetails;
         const int Fields = 3;
         const int MaxSizeInInfoMap = 8 * 1024;
 
@@ -79,6 +80,12 @@ namespace Microsoft.Azure.Amqp.Framing
             {
                 error.Condition = AmqpErrorCode.InternalError;
                 error.Description = AmqpResources.GetString(AmqpResources.AmqpErrorOccurred, AmqpErrorCode.InternalError);
+            }
+
+            // Set the error details if 'IncludeErrorDetails' is set explicitly
+            if (IncludeErrorDetails)
+            {
+                error.Description = exception.Message;
             }
 
 #if DEBUG

--- a/Microsoft.Azure.Amqp/Properties/AssemblyInfo.cs
+++ b/Microsoft.Azure.Amqp/Properties/AssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 
 // Version information for an assembly follows semantic versioning 1.0.0 (because
 // NuGet didn't support semver 2.0.0 before VS 2015). See semver.org for details.
-[assembly: AssemblyInformationalVersion("2.0.3")]
+[assembly: AssemblyInformationalVersion("2.0.5")]


### PR DESCRIPTION
This will enable application to keep the 1.0 library behavior which will keep the error description. Updated the assembly version so that we can release new nuget package.