### PR TITLE
Invoking closeHandler on AmqpObject.Close event in FaultTolerantAmqpObject

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/FaultTolerantAmqpObject.cs
+++ b/Microsoft.Azure.Amqp/Amqp/FaultTolerantAmqpObject.cs
@@ -45,8 +45,7 @@ namespace Microsoft.Azure.Amqp
         protected override async Task<T> OnCreateAsync(TimeSpan timeout)
         {
             T amqpObject = await this.createObjectAsync(timeout);
-            amqpObject.SafeAddClosed((s, e) => this.Invalidate(amqpObject));
-
+            amqpObject.SafeAddClosed(OnObjectClosed);
             return amqpObject;
         }
 


### PR DESCRIPTION
Fixing an issue where FaultTolerantAmqpObject doesn't invoke the close handler on Close event fired by the AmqpObject.