### PR TITLE
Update TlsTransport.cs

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/Transport/TlsTransport.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Transport/TlsTransport.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Amqp.Transport
         static readonly AsyncCallback onWriteComplete = OnWriteComplete;
         static readonly AsyncCallback onReadComplete = OnReadComplete;
         readonly TransportBase innerTransport;
-        readonly CustomSslStream sslStream;
+        protected readonly CustomSslStream sslStream;
         TlsTransportSettings tlsSettings;
         OperationState writeState;
         OperationState readState;


### PR DESCRIPTION
Make Sslstream a protected member so that derived classes can get access to it.

We need access to Sslstream in order to get information regarding the actual cipher suites being used.