### PR TITLE
Remove 'sealed' tag from sasltransport and sasltransportprovider (#119)

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/Sasl/SaslTransport.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Sasl/SaslTransport.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.Amqp.Sasl
     using System.Security.Principal;
     using Microsoft.Azure.Amqp.Transport;
 
-    public sealed class SaslTransport : TransportBase
+    public class SaslTransport : TransportBase
     {
-        readonly TransportBase innerTransport;
+        protected readonly TransportBase innerTransport;
         SaslNegotiator negotiator;
 
         public SaslTransport(TransportBase transport, SaslTransportProvider provider, bool isInitiator)

--- a/Microsoft.Azure.Amqp/Amqp/Sasl/SaslTransportProvider.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Sasl/SaslTransportProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Amqp.Sasl
     using System.Collections.Generic;
     using Microsoft.Azure.Amqp.Transport;
 
-    public sealed class SaslTransportProvider : TransportProvider
+    public class SaslTransportProvider : TransportProvider
     {
         Dictionary<string, SaslHandler> handlers;
 


### PR DESCRIPTION
* Update SaslTransport.cs

Remove 'sealed' tag. Also make 'innerTransport' accessible to derived classes.

* Update SaslTransportProvider.cs

remove 'sealed' tag from SaslTransportProvider.