### PR TITLE
Add lock around AmqpLink.unsettledMap reads

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/AmqpLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/AmqpLink.cs
@@ -269,7 +269,13 @@ namespace Microsoft.Azure.Amqp
         public bool DisposeDelivery(ArraySegment<byte> deliveryTag, bool settled, DeliveryState state, bool batchable)
         {
             Delivery delivery = null;
-            if (this.unsettledMap.TryGetValue(deliveryTag, out delivery))
+            bool result = false;
+            lock (this.syncRoot)
+            {
+                result = this.unsettledMap.TryGetValue(deliveryTag, out delivery);
+            }
+
+            if (result)
             {
                 delivery.Batchable = batchable;
                 this.DisposeDelivery(delivery, settled, state);
@@ -361,7 +367,13 @@ namespace Microsoft.Azure.Amqp
         public void CompleteDelivery(ArraySegment<byte> deliveryTag)
         {
             Delivery delivery = null;
-            if (this.unsettledMap.TryGetValue(deliveryTag, out delivery))
+            bool result = false;
+            lock (this.syncRoot)
+            {
+                result = this.unsettledMap.TryGetValue(deliveryTag, out delivery);
+            }
+
+            if (result) 
             {
                 this.DisposeDelivery(delivery, true, delivery.State);
             }


### PR DESCRIPTION
**Overview:**
I am seeing NullReferenceExceptions thrown in AmqpLink.CompleteDelivery, because delivery object returned here is null - https://github.com/Azure/azure-amqp/blob/0a04c100d66736eed64832e4655a0099190354c9/Microsoft.Azure.Amqp/Amqp/AmqpLink.cs#L364

**Issue:**
https://github.com/Azure/azure-amqp/issues/131

**Fix:**
This PR attempts to fix that issue by locking around the reads of the unsettledMap, just like with the add/remove.