### PR TITLE
Fixing a bug where transaction controller is not recovering from a fault

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/Transaction/Controller.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Transaction/Controller.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Azure.Amqp.Transaction
             try
             {
                 thisPtr.controllerLink.EndOpen(asyncResult);
+                thisPtr.controllerLink.SafeAddClosed((sender, args) => { thisPtr.SafeClose(); });
             }
             catch (Exception exception) when (!Fx.IsFatal(exception))
             {


### PR DESCRIPTION
Controller is not closing when inner sendlink is closed. It is holding on to a closed send link and will never recover after a fault. Fixing it by closing the contoller when the inner send link is closed.