### PR TITLE
Consistently apply ConfigureAwait(false)

### DIFF
--- a/src/AmqpConnection.cs
+++ b/src/AmqpConnection.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Amqp
             AmqpSession session = this.CreateSession(sessionSettings);
             try
             {
-                await session.OpenAsync();
+                await session.OpenAsync().ConfigureAwait(false);
                 return session;
             }
             catch
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Amqp
             }
             else
             {
-                ProtocolHeader supportedHeader = this.amqpSettings.GetSupportedHeader(header);                
+                ProtocolHeader supportedHeader = this.amqpSettings.GetSupportedHeader(header);
                 this.SendProtocolHeader(supportedHeader);
                 if (!supportedHeader.Equals(header))
                 {
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.Amqp
             {
                 this.SendOpen();
             }
-            
+
             if(this.isInitiator)
             {
                 // check if open returned an error right away

--- a/src/AmqpSession.cs
+++ b/src/AmqpSession.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Amqp
             try
             {
                 link.AttachTo(this);
-                await link.OpenAsync();
+                await link.OpenAsync().ConfigureAwait(false);
 
                 return link as T;
             }
@@ -1091,7 +1091,7 @@ namespace Microsoft.Azure.Amqp
 
                     this.Session.SendCommand(transfer, payload);
                 }
-                
+
                 return true;
             }
 

--- a/src/Cbs/AmqpCbsLink.cs
+++ b/src/Cbs/AmqpCbsLink.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Amqp
                 throw new OperationCanceledException("Connection is closing or closed.");
             }
 
-            CbsToken token = await tokenProvider.GetTokenAsync(namespaceAddress, resource, requiredClaims);
+            CbsToken token = await tokenProvider.GetTokenAsync(namespaceAddress, resource, requiredClaims).ConfigureAwait(false);
             string tokenType = token.TokenType;
             if (tokenType == null)
             {
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Amqp
             RequestResponseAmqpLink requestResponseLink;
             if (!this.linkFactory.TryGetOpenedObject(out requestResponseLink))
             {
-                requestResponseLink = await this.linkFactory.GetOrCreateAsync(timeout);
+                requestResponseLink = await this.linkFactory.GetOrCreateAsync(timeout).ConfigureAwait(false);
             }
 
             AmqpValue value = new AmqpValue();
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Amqp
             putTokenRequest.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = audience;
             putTokenRequest.ApplicationProperties.Map[CbsConstants.PutToken.Expiration] = token.ExpiresAtUtc;
 
-            AmqpMessage putTokenResponse = await requestResponseLink.RequestAsync(putTokenRequest, timeout);
+            AmqpMessage putTokenResponse = await requestResponseLink.RequestAsync(putTokenRequest, timeout).ConfigureAwait(false);
 
             int statusCode = (int)putTokenResponse.ApplicationProperties.Map[CbsConstants.PutToken.StatusCode];
             string statusDescription = (string)putTokenResponse.ApplicationProperties.Map[CbsConstants.PutToken.StatusDescription];
@@ -129,12 +129,12 @@ namespace Microsoft.Azure.Amqp
                 {
                     AmqpSessionSettings sessionSettings = new AmqpSessionSettings() { Properties = new Fields() };
                     session = this.connection.CreateSession(sessionSettings);
-                    await session.OpenAsync(timeoutHelper.RemainingTime());
+                    await session.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                     Fields properties = new Fields();
                     properties.Add(CbsConstants.TimeoutName, (uint)timeoutHelper.RemainingTime().TotalMilliseconds);
                     link = new RequestResponseAmqpLink("cbs", session, address, properties);
-                    await link.OpenAsync(timeoutHelper.RemainingTime());
+                    await link.OpenAsync(timeoutHelper.RemainingTime()).ConfigureAwait(false);
 
                     AmqpTrace.Provider.AmqpOpenEntitySucceeded(this, link.Name, address);
                     return link;
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Amqp
                     AmqpTrace.Provider.AmqpOpenEntityFailed(this, this.GetType().Name, address, exception);
                 }
 
-                await Task.Delay(1000);
+                await Task.Delay(1000).ConfigureAwait(false);
             }
 
             link?.Abort();

--- a/src/Fx/Singleton.cs
+++ b/src/Fx/Singleton.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Amqp
                         tcs.SetException(ex);
                     }
 
-                    return await tcs.Task;
+                    return await tcs.Task.ConfigureAwait(false);
                 }
             }
 

--- a/src/Transaction/Controller.cs
+++ b/src/Transaction/Controller.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Amqp.Transaction
             AmqpMessage message = Controller.CreateCommandMessage(declare);
             DeliveryState deliveryState = await Task<DeliveryState>.Factory.FromAsync(
                 this.controllerLink.BeginSendMessage(message, this.GetDeliveryTag(), AmqpConstants.NullBinary, this.operationTimeout, null, null),
-                this.controllerLink.EndSendMessage);
+                this.controllerLink.EndSendMessage).ConfigureAwait(false);
 
             this.ThrowIfRejected(deliveryState);
             AmqpTrace.Provider.AmqpLogOperationInformational(this, TraceOperation.Execute, "EndDeclare");
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Amqp.Transaction
             AmqpMessage message = Controller.CreateCommandMessage(discharge);
             DeliveryState deliveryState = await Task<DeliveryState>.Factory.FromAsync(
                 this.controllerLink.BeginSendMessage(message, this.GetDeliveryTag(), AmqpConstants.NullBinary, this.operationTimeout, null, null),
-                this.controllerLink.EndSendMessage);
+                this.controllerLink.EndSendMessage).ConfigureAwait(false);
             this.ThrowIfRejected(deliveryState);
             AmqpTrace.Provider.AmqpLogOperationInformational(this, TraceOperation.Execute, "EndDischange");
         }


### PR DESCRIPTION
This PR consistently applies `ConfigureAwait(false)` like a library that is a good async citizen should do