### PR TITLE
Create TaskCompletionSource with TaskCreationOptions.RunContinuationsAsynchronously

### DIFF
--- a/src/Fx/Singleton.cs
+++ b/src/Fx/Singleton.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Amqp
                     this.Invalidate(current);
                 }
 
-                tcs = new TaskCompletionSource<TValue>();
+                tcs = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
                 if (this.TrySet(tcs))
                 {
                     try

--- a/src/Transport/AmqpTransportInitiator.cs
+++ b/src/Transport/AmqpTransportInitiator.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Amqp.Transport
         /// <returns>A task that returns a transport when it is completed.</returns>
         public Task<TransportBase> ConnectAsync(TimeSpan timeout)
         {
-            var tcs = new TaskCompletionSource<TransportBase>();
+            var tcs = new TaskCompletionSource<TransportBase>(TaskCreationOptions.RunContinuationsAsynchronously);
             var args = new TransportAsyncCallbackArgs
             {
                 CompletedCallback = a =>
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
             AmqpTrace.Provider.AmqpLogOperationInformational(this, TraceOperation.Execute, "ReadHeader");
             byte[] headerBuffer = new byte[AmqpConstants.ProtocolHeaderSize];
-            args.SetBuffer(headerBuffer, 0, headerBuffer.Length); 
+            args.SetBuffer(headerBuffer, 0, headerBuffer.Length);
             args.CompletedCallback = this.OnReadHeaderComplete;
             this.reader.ReadBuffer(args);
         }


### PR DESCRIPTION
Maybe it was intentional to not create the TaskCompletionSources with `TaskCreationOptions.RunContinuationsAsynchronously`. If not then this PR might be handy.

It is considered good practice to create TaskCompletionSource with `TaskCreationOptions.RunContinuationsAsynchronously` to avoid reentering on the same thread that called `Set` or `TrySet` methods. This also avoids deep call stack diving

More information see

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously
https://stackoverflow.com/questions/28321457/taskcontinuationoptions-runcontinuationsasynchronously-and-stack-dives