### PR TITLE
Deregister event handlers

### DIFF
--- a/src/AmqpConnection.cs
+++ b/src/AmqpConnection.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Amqp
             }
             else
             {
-                ProtocolHeader supportedHeader = this.amqpSettings.GetSupportedHeader(header);                
+                ProtocolHeader supportedHeader = this.amqpSettings.GetSupportedHeader(header);
                 this.SendProtocolHeader(supportedHeader);
                 if (!supportedHeader.Equals(header))
                 {
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.Amqp
             {
                 this.SendOpen();
             }
-            
+
             if(this.isInitiator)
             {
                 // check if open returned an error right away
@@ -639,6 +639,7 @@ namespace Microsoft.Azure.Amqp
             {
                 lock (thisPtr.ThisLock)
                 {
+                    session.Closed -= onSessionClosed;
                     thisPtr.sessionsByLocalHandle.Remove(session.LocalChannel);
                     if (session.RemoteChannel.HasValue)
                     {

--- a/src/AmqpSession.cs
+++ b/src/AmqpSession.cs
@@ -635,6 +635,7 @@ namespace Microsoft.Azure.Amqp
             AmqpSession thisPtr = link.Session;
             lock (thisPtr.ThisLock)
             {
+                link.Closed -= onLinkClosed;
                 thisPtr.links.Remove(link.Name);
                 if (link.LocalHandle.HasValue)
                 {

--- a/src/Transport/AmqpTransportListener.cs
+++ b/src/Transport/AmqpTransportListener.cs
@@ -98,11 +98,14 @@ namespace Microsoft.Azure.Amqp.Transport
 
         void OnListenerClosed(object sender, EventArgs e)
         {
+            TransportListener innerListener = (TransportListener)sender;
+            EventHandler onListenerClose = this.OnListenerClosed;
+            innerListener.Closed -= onListenerClose;
+
             if (!this.IsClosing())
             {
                 // If we weren't shutting down then this class needs to Close itself (with the TerminalException) since
                 // it is no longer doing all the listening it is supposed to do.
-                TransportListener innerListener = (TransportListener)sender;
                 AmqpTrace.Provider.AmqpLogError(this, "OnListenerClosed", innerListener.TerminalException);
                 this.SafeClose(innerListener.TerminalException);
             }

--- a/src/Transport/TlsTransportListener.cs
+++ b/src/Transport/TlsTransportListener.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Azure.Amqp.Transport
 {
     using System;
-    
+
     /// <summary>
     /// This listener accepts TLS transport directly (no TLS upgrade).
     /// </summary>
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Amqp.Transport
         {
             TransportSettings innerSettings = this.transportSettings.InnerTransportSettings;
             this.innerListener = innerSettings.CreateListener();
-            this.innerListener.Closed += new EventHandler(OnInnerListenerClosed);
+            this.innerListener.Closed += OnInnerListenerClosed;
             this.innerListener.Listen(this.OnAcceptInnerTransport);
         }
 
@@ -74,9 +74,11 @@ namespace Microsoft.Azure.Amqp.Transport
 
         void OnInnerListenerClosed(object sender, EventArgs e)
         {
+            TransportListener innerListener = (TransportListener)sender;
+            innerListener.Closed -= OnInnerListenerClosed;
+
             if (!this.IsClosing())
             {
-                TransportListener innerListener = (TransportListener)sender;
                 this.SafeClose(innerListener.TerminalException);
             }
         }
@@ -92,7 +94,7 @@ namespace Microsoft.Azure.Amqp.Transport
                 // upgrade transport
                 innerArgs.Transport = this.OnCreateTransport(innerArgs.Transport, this.transportSettings);
                 IAsyncResult result = innerArgs.Transport.BeginOpen(
-                    AmqpConstants.DefaultTimeout, 
+                    AmqpConstants.DefaultTimeout,
                     this.onTransportOpened,
                     innerArgs);
                 if (result.CompletedSynchronously)


### PR DESCRIPTION
If needed this PR would remove the event handler registration when the object it was linked to was closed