### PR TITLE
Readonly struct where possible

### DIFF
--- a/src/AmqpMessageReader.cs
+++ b/src/AmqpMessageReader.cs
@@ -8,23 +8,40 @@ namespace Microsoft.Azure.Amqp
     using Microsoft.Azure.Amqp.Encoding;
     using Microsoft.Azure.Amqp.Framing;
 
-    struct Section
+    readonly struct Section
     {
-        public SectionFlag Flag;
-        public int Offset;
-        public int Length;
-        public AmqpDescribed Value;
+        public readonly SectionFlag Flag;
+        public readonly int Offset;
+        public readonly int Length;
+        public readonly AmqpDescribed Value;
+
+        public Section(SectionFlag flag, int offset, int length, AmqpDescribed value)
+        {
+            Flag = flag;
+            Offset = offset;
+            Length = length;
+            Value = value;
+        }
     }
 
     sealed class AmqpMessageReader
     {
-        struct SectionInfo
+        readonly struct SectionInfo
         {
-            public SectionFlag Flag;
-            public ulong Code;
-            public string Name;
-            public Func<AmqpDescribed> Ctor;
-            public Func<byte, ByteBuffer, Error> Scanner;
+            public readonly SectionFlag Flag;
+            public readonly ulong Code;
+            public readonly string Name;
+            public readonly Func<AmqpDescribed> Ctor;
+            public readonly Func<byte, ByteBuffer, Error> Scanner;
+
+            public SectionInfo(SectionFlag flag, ulong code, string name, Func<AmqpDescribed> ctor, Func<byte, ByteBuffer, Error> scanner)
+            {
+                Flag = flag;
+                Code = code;
+                Name = name;
+                Ctor = ctor;
+                Scanner = scanner;
+            }
         }
 
         static readonly SectionInfo[] MessageSections;
@@ -33,78 +50,59 @@ namespace Microsoft.Azure.Amqp
         {
             MessageSections = new SectionInfo[]
             {
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.Header,
-                    Code = Header.Code,
-                    Name = Header.Name,
-                    Ctor = () => new Header(),
-                    Scanner = (a, b) => ScanListSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.DeliveryAnnotations,
-                    Code = DeliveryAnnotations.Code,
-                    Name = DeliveryAnnotations.Name,
-                    Ctor = () => new DeliveryAnnotations(),
-                    Scanner = (a, b) => ScanMapSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.MessageAnnotations,
-                    Code = MessageAnnotations.Code,
-                    Name = MessageAnnotations.Name,
-                    Ctor = () => new MessageAnnotations(),
-                    Scanner = (a, b) => ScanMapSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.Properties,
-                    Code = Properties.Code,
-                    Name = Properties.Name,
-                    Ctor = () => new Properties(),
-                    Scanner = (a, b) => ScanListSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.ApplicationProperties,
-                    Code = ApplicationProperties.Code,
-                    Name = ApplicationProperties.Name,
-                    Ctor = () => new ApplicationProperties(),
-                    Scanner = (a, b) => ScanMapSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.Data,
-                    Code = Data.Code,
-                    Name = Data.Name,
-                    Ctor = () => new Data(),
-                    Scanner = (a, b) => ScanDataSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.AmqpSequence,
-                    Code = AmqpSequence.Code,
-                    Name = AmqpSequence.Name,
-                    Ctor = () => new AmqpSequence(),
-                    Scanner = (a, b) => ScanListSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.AmqpValue,
-                    Code = AmqpValue.Code,
-                    Name = AmqpValue.Name,
-                    Ctor = () => new AmqpValue(),
-                    Scanner = (a, b) => ScanValueSection(a, b)
-                },
-                new SectionInfo()
-                {
-                    Flag = SectionFlag.Footer,
-                    Code = Footer.Code,
-                    Name = Footer.Name,
-                    Ctor = () => new Footer(),
-                    Scanner = (a, b) => ScanMapSection(a, b)
-                },
+                new SectionInfo(
+                    flag: SectionFlag.Header,
+                    code: Header.Code,
+                    name: Header.Name,
+                    ctor: () => new Header(),
+                    scanner: (a, b) => ScanListSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.DeliveryAnnotations,
+                    code: DeliveryAnnotations.Code,
+                    name: DeliveryAnnotations.Name,
+                    ctor: () => new DeliveryAnnotations(),
+                    scanner: (a, b) => ScanMapSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.MessageAnnotations,
+                    code: MessageAnnotations.Code,
+                    name: MessageAnnotations.Name,
+                    ctor: () => new MessageAnnotations(),
+                    scanner: (a, b) => ScanMapSection(a, b)),
+                new SectionInfo(flag: SectionFlag.Properties,
+                    code: Properties.Code,
+                    name: Properties.Name,
+                    ctor: () => new Properties(),
+                    scanner: (a,  b) => ScanListSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.ApplicationProperties,
+                    code: ApplicationProperties.Code,
+                    name: ApplicationProperties.Name,
+                    ctor: () => new ApplicationProperties(),
+                    scanner: (a, b) => ScanMapSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.Data,
+                    code: Data.Code,
+                    name: Data.Name,
+                    ctor: () => new Data(),
+                    scanner: (a, b) => ScanDataSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.AmqpSequence,
+                    code: AmqpSequence.Code,
+                    name: AmqpSequence.Name,
+                    ctor: () => new AmqpSequence(),
+                    scanner: (a, b) => ScanListSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.AmqpValue,
+                    code: AmqpValue.Code,
+                    name: AmqpValue.Name,
+                    ctor: () => new AmqpValue(),
+                    scanner: (a, b) => ScanValueSection(a, b)),
+                new SectionInfo(
+                    flag: SectionFlag.Footer,
+                    code: Footer.Code,
+                    name: Footer.Name,
+                    ctor: () => new Footer(),
+                    scanner: (a, b) => ScanMapSection(a, b)),
             };
 
             for (int i = 0; i < MessageSections.Length; i++)
@@ -174,7 +172,7 @@ namespace Microsoft.Azure.Amqp
                             length = buffer.Offset - offset;
                         }
 
-                        Section s = new Section() { Flag = info.Flag, Offset = offset, Length = length, Value = section };
+                        Section s = new Section(info.Flag, offset, length, section);
                         bool shouldContinue = sectionHandler(t1, t2, s);
 
                         if (!shouldContinue)

--- a/src/AmqpSession.cs
+++ b/src/AmqpSession.cs
@@ -837,7 +837,7 @@ namespace Microsoft.Azure.Amqp
 
                 if (toDispose != null)
                 {
-                    this.SendDisposition(new DispositionInfo() { First = toDispose });
+                    this.SendDisposition(new DispositionInfo(toDispose));
                     if (delivery.Settled)
                     {
                         this.OnWindowMoved(1);
@@ -977,7 +977,7 @@ namespace Microsoft.Azure.Amqp
                                 }
                                 else
                                 {
-                                    disposedDeliveries.Add(new DispositionInfo() { First = firstChanged, Last = lastId });
+                                    disposedDeliveries.Add(new DispositionInfo(firstChanged, lastId));
                                     firstChanged = current;
                                     lastId = null;
                                 }
@@ -1001,7 +1001,7 @@ namespace Microsoft.Azure.Amqp
                         {
                             if (firstChanged != null)
                             {
-                                disposedDeliveries.Add(new DispositionInfo() { First = firstChanged, Last = lastId });
+                                disposedDeliveries.Add(new DispositionInfo(firstChanged, lastId));
                                 firstChanged = null;
                                 lastId = null;
                             }
@@ -1012,7 +1012,7 @@ namespace Microsoft.Azure.Amqp
 
                     if (firstChanged != null)
                     {
-                        disposedDeliveries.Add(new DispositionInfo() { First = firstChanged, Last = lastId });
+                        disposedDeliveries.Add(new DispositionInfo(firstChanged, lastId));
                     }
 
                     this.sendingDisposition = false;
@@ -1058,10 +1058,17 @@ namespace Microsoft.Azure.Amqp
                 }
             }
 
-            struct DispositionInfo
+            readonly struct DispositionInfo
             {
-                public Delivery First;
-                public uint? Last;
+                public DispositionInfo(Delivery first, uint? last = null)
+                {
+                    First = first;
+                    Last = last;
+                }
+
+                public Delivery First { get; }
+
+                public uint? Last { get; }
             }
         }
 

--- a/src/AmqpVersion.cs
+++ b/src/AmqpVersion.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Amqp
     /// <summary>
     /// Defines an AMQP version.
     /// </summary>
-    public struct AmqpVersion : IEquatable<AmqpVersion>
+    public readonly struct AmqpVersion : IEquatable<AmqpVersion>
     {
         /// <summary>
         /// The 1.0.0 version.

--- a/src/ByteBuffer.cs
+++ b/src/ByteBuffer.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Amqp
                     {
                         newBuffer = new ManagedBuffer(new byte[newSize], null);
                     }
-                    
+
                     System.Buffer.BlockCopy(this.buffer, this.start, newBuffer.Buffer, 0, this.Capacity);
 
                     int consumed = this.read - this.start;
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.Amqp
             this.write = this.end = segment.Offset + segment.Count;
         }
 
-        struct ManagedBuffer
+        readonly struct ManagedBuffer
         {
             public readonly InternalBufferManager BufferManager;
 

--- a/src/Encoding/AmqpSymbol.cs
+++ b/src/Encoding/AmqpSymbol.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Amqp.Encoding
     /// <summary>
     /// Implements the AMQP symbol type.
     /// </summary>
-    public struct AmqpSymbol : IEquatable<AmqpSymbol>
+    public readonly struct AmqpSymbol : IEquatable<AmqpSymbol>
     {
         /// <summary>
         /// Initializes the object from a string.
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Amqp.Encoding
         public string Value
         {
             get;
-            private set;
         }
 
         /// <summary>
@@ -34,7 +33,7 @@ namespace Microsoft.Azure.Amqp.Encoding
         /// <param name="value">The string.</param>
         public static implicit operator AmqpSymbol(string value)
         {
-            return new AmqpSymbol() { Value = value };
+            return new AmqpSymbol(value);
         }
 
         /// <summary>

--- a/src/Encoding/FormatCode.cs
+++ b/src/Encoding/FormatCode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Amqp.Encoding
     using System;
     using System.Globalization;
 
-    struct FormatCode : IEquatable<FormatCode>
+    readonly struct FormatCode : IEquatable<FormatCode>
     {
         public const byte Described = 0x00;
 
@@ -55,8 +55,8 @@ namespace Microsoft.Azure.Amqp.Encoding
         public const byte Array8 = 0xe0;
         public const byte Array32 = 0xf0;
 
-        byte type;
-        byte extType;
+        readonly byte type;
+        readonly byte extType;
 
         public FormatCode(byte type) :
             this(type, 0)
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Amqp.Encoding
         {
             return (type & 0xF) == 0xF;
         }
- 
+
         public static implicit operator FormatCode(byte value)
         {
             return new FormatCode(value);
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Amqp.Encoding
         }
 
         public override bool Equals(object obj)
-        {            
+        {
             return obj is FormatCode && this == (FormatCode)obj;
         }
 

--- a/src/Encoding/MapKey.cs
+++ b/src/Encoding/MapKey.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.Amqp.Encoding
     /// <summary>
     /// Defines the key type used in <see cref="AmqpMap"/>.
     /// </summary>
-    public struct MapKey : IEquatable<MapKey>
+    public readonly struct MapKey : IEquatable<MapKey>
     {
-        object key;
+        readonly object key;
 
         /// <summary>
         /// Initializes the key from an object.

--- a/src/Fx/Timestamp.cs
+++ b/src/Fx/Timestamp.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Amqp
     // This class is immune to clock jump with the following two exceptions:
     //  - When multi-processor machine has a bug in BIOS/HAL that returns inconsistent clock tick for different processor.
     //  - When the machine does not support high frequency CPU tick.
-    struct Timestamp : IComparable<Timestamp>, IEquatable<Timestamp>
+    readonly struct Timestamp : IComparable<Timestamp>, IEquatable<Timestamp>
     {
         static readonly double TickFrequency = 10000000.0 / Stopwatch.Frequency;
         readonly long timestamp;

--- a/src/Microsoft.Azure.Amqp.csproj
+++ b/src/Microsoft.Azure.Amqp.csproj
@@ -22,12 +22,13 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <Configurations>Debug;Release;Signed</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <OutputPath>..\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <Optimize>true</Optimize>
     <OutputPath>..\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>


### PR DESCRIPTION
For improved expressiveness and to reduce the risk of accidental assignment of values where not intended I made the structs `readonly` where possible.

According to Jared making a public struct where the members are readonly `readonly struct` is a non breaking change

https://blog.paranoidcoding.com/2019/03/27/readonly-struct-breaking-change.html

I've made a separate commit for the public structs in case you want to drop that.

> Some of you may have noticed that C# 7.3 already shipped, back in Visual Studio 2017 update 15.7

https://devblogs.microsoft.com/dotnet/a-belated-welcome-to-c-7-3/

the defaults mentioned here don't apply for VS 2017. For VS2017 it is necessary to set the language version.

https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version#defaults