### PR TITLE
Array Encoding/Decoding performance improvements

### DIFF
--- a/src/AmqpCodec.cs
+++ b/src/AmqpCodec.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Amqp
         /// <returns>Encode size in bytes of the array.</returns>
         public static int GetArrayEncodeSize<T>(T[] value)
         {
-            return ArrayEncoding.GetEncodeSize(value);
+            return ArrayEncoding.GetEncodeSize<T>(value);
         }
 
         /// <summary>
@@ -580,7 +580,7 @@ namespace Microsoft.Azure.Amqp
         /// <param name="buffer">The destination buffer.</param>
         public static void EncodeArray<T>(T[] data, ByteBuffer buffer)
         {
-            ArrayEncoding.Encode(data, buffer);
+            ArrayEncoding.Encode<T>(data, buffer);
         }
 
         /// <summary>

--- a/src/ByteBuffer.cs
+++ b/src/ByteBuffer.cs
@@ -457,6 +457,16 @@ namespace Microsoft.Azure.Amqp
             }
         }
 
+        internal ReadOnlySpan<byte> GetReadSpan()
+        {
+            return this.buffer.AsSpan(this.Offset, this.Length);
+        }
+
+        internal Span<byte> GetWriteSpan()
+        {
+            return this.buffer.AsSpan(this.WritePos, this.Size);
+        }
+
         [Conditional("DEBUG")]
         internal void AssertReferences(int value)
         {

--- a/src/Encoding/PrimitiveEncoding.cs
+++ b/src/Encoding/PrimitiveEncoding.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Amqp.Encoding
+{
+    using System;
+    using System.Collections;
+
+    abstract class PrimitiveEncoding : EncodingBase
+    {
+        protected PrimitiveEncoding(FormatCode formatCode)
+            : base(formatCode)
+        {
+        }
+
+        public abstract int GetArrayEncodeSize(IList value);
+
+        public abstract void EncodeArray(IList value, ByteBuffer buffer);
+        public abstract Array DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode);
+    }
+}

--- a/src/Framing/Multiple.cs
+++ b/src/Framing/Multiple.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Amqp.Framing
             }
             else
             {
-                return ArrayEncoding.GetEncodeSize(multiple.ToArray());
+                return ArrayEncoding.GetEncodeSize<T>(multiple);
             }
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Amqp.Framing
             }
             else
             {
-                ArrayEncoding.Encode(multiple.ToArray(), buffer);
+                ArrayEncoding.Encode<T>(multiple, buffer);
             }
         }
 

--- a/src/Microsoft.Azure.Amqp.csproj
+++ b/src/Microsoft.Azure.Amqp.csproj
@@ -43,6 +43,8 @@
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="LICENSE.txt"/>
     <None Include="..\icon.png" Pack="true" PackagePath="\"/>
+
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a work in progress to show how array encoding/decoding of primitive types can be improved. The basic idea is to eliminate boxing and unboxing of primitive types. And to eliminate some unnecessary allocations when using `Multiple<T>`.

If this approach looks acceptable, I will complete the other primitive type encodings and mark the PR as "ready for review".

Using the benchmark test located at: https://gist.github.com/eerhardt/db06d97c93faaae9b9aec79811c94559, I am seeing the following micro-benchmark results:

#### Master branch:
|                         Method |          Mean |        Error |       StdDev |        Median |      Gen 0 |   Gen 1 |  Gen 2 |  Allocated |
|------------------------------- |--------------:|-------------:|-------------:|--------------:|-----------:|--------:|-------:|-----------:|
|   ArrayAmqpSymbolDecode_1M_MAA |     960.52 us |    17.759 us |    15.743 us |     960.93 us |   126.9531 | 52.7344 |      - |   647112 B |
|   ArrayAmqpSymbolDecode_1K_MAA |      82.93 us |     1.631 us |     3.369 us |      81.41 us |    15.5029 |       - |      - |    65192 B |
| ArrayAmqpSymbolEncode_100K_MAA |   1,889.03 us |    27.619 us |    23.063 us |   1,891.84 us |   195.3125 |       - |      - |   819299 B |
|   ArrayAmqpSymbolEncode_1K_MAA |     190.24 us |     2.058 us |     1.925 us |     189.96 us |    19.5313 |       - |      - |    82144 B |
|               Bytes_Encode_MAA |      34.47 us |     0.653 us |     0.699 us |      34.30 us |          - |       - |      - |          - |
|               Bytes_Decode_MAA |     684.08 us |    12.820 us |    12.591 us |     687.00 us |     7.8125 |  7.8125 | 7.8125 |  1048600 B |
|        ArrayInt32Encode_MAA_1M | 134,211.00 us | 2,334.898 us | 2,184.065 us | 134,368.90 us | 12000.0000 |       - |      - | 50332094 B |
|        ArrayInt32Encode_MAA_1K |     129.48 us |     1.753 us |     1.639 us |     129.66 us |    11.7188 |       - |      - |    49264 B |
|        ArrayInt32Decode_1M_MAA | 103,514.40 us | 1,373.994 us | 1,285.235 us | 103,510.78 us |  6000.0000 |       - |      - | 29360299 B |
|        ArrayInt32Decode_1K_MAA |      99.03 us |     1.256 us |     1.113 us |      99.29 us |     6.8359 |       - |      - |    28696 B |

#### PR changes:

|                         Method |         Mean |      Error |     StdDev |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------------------------- |-------------:|-----------:|-----------:|--------:|--------:|--------:|----------:|
|   ArrayAmqpSymbolDecode_1M_MAA |   738.915 us |  9.8911 us |  8.2595 us | 79.1016 | 32.2266 |       - |  401359 B |
|   ArrayAmqpSymbolDecode_1K_MAA |    67.218 us |  0.7661 us |  0.7166 us |  9.6436 |  0.2441 |       - |   40616 B |
| ArrayAmqpSymbolEncode_100K_MAA |   528.316 us |  7.6527 us |  7.1584 us |       - |       - |       - |     169 B |
|   ArrayAmqpSymbolEncode_1K_MAA |    51.165 us |  0.7409 us |  0.6187 us |       - |       - |       - |     136 B |
|               Bytes_Encode_MAA |    34.367 us |  0.6847 us |  0.7031 us |       - |       - |       - |         - |
|               Bytes_Decode_MAA |   723.398 us |  8.8652 us |  8.2926 us |  7.8125 |  7.8125 |  7.8125 | 1048600 B |
|        ArrayInt32Encode_MAA_1M | 2,208.596 us | 26.4736 us | 23.4681 us |       - |       - |       - |         - |
|        ArrayInt32Encode_MAA_1K |     2.227 us |  0.0441 us |   0.0977 us |     2.206 us |       - |       - |       - |         - |
|        ArrayInt32Decode_1M_MAA | 3,425.374 us | 52.6210 us | 41.0830 us | 31.2500 | 31.2500 | 31.2500 | 4194333 B |
|        ArrayInt32Decode_1K_MAA |     1.518 us |  0.0253 us |  0.0224 us |  0.9842 |       - |       - |    4120 B |

cc @xinchen10 - let me know what you think about the approach, and if I should continue this work.