### PR TITLE
Ensure Singleton Closes Any Opened Object During Concurrent Open/Close

### DIFF
--- a/src/Fx/Singleton.cs
+++ b/src/Fx/Singleton.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Amqp
             {
                 this.disposed = true;
                 var thisTaskCompletionSource = this.taskCompletionSource;
-                if (thisTaskCompletionSource != null && thisTaskCompletionSource.Task.Status == TaskStatus.RanToCompletion)
+                if (thisTaskCompletionSource != null && thisTaskCompletionSource.Task.Status == TaskStatus.RanToCompletion && this.TryRemove())
                 {
                     OnSafeClose(thisTaskCompletionSource.Task.Result);
                 }
@@ -126,6 +126,11 @@ namespace Microsoft.Azure.Amqp
                     {
                         TValue value = await this.OnCreateAsync(timeout).ConfigureAwait(false);
                         tcs.SetResult(value);
+
+                        if (this.disposed && this.TryRemove())
+                        {
+                          OnSafeClose(value);
+                        }
                     }
                     catch (Exception ex) when (!Fx.IsFatal(ex))
                     {

--- a/test/Test.Microsoft.Amqp/TestCases/SingletonTests.cs
+++ b/test/Test.Microsoft.Amqp/TestCases/SingletonTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.Amqp;
+using Xunit;
+
+namespace Test.Microsoft.Azure.Amqp
+{
+    public class SingletonTests
+    {
+        [Fact]
+        public async Task SingletonConcurrentCloseOpenTests()
+        {
+            var createTcs = new TaskCompletionSource<object>();
+            var closeTcs = new TaskCompletionSource<object>();
+
+            var singleton = new SingletonTester(createTcs.Task, closeTcs.Task);
+
+            var creating = singleton.GetOrCreateAsync(TimeSpan.FromSeconds(1));
+            var closing = singleton.CloseAsync();
+
+            closeTcs.SetResult(new object());
+            await closing;
+
+            createTcs.SetResult(new object());
+            await creating;
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => singleton.GetOrCreateAsync(TimeSpan.FromSeconds(1)));
+
+            var createdObj = GetInternalProperty<object>(singleton, "Value");
+            Assert.Null(createdObj);
+        }
+
+        private class SingletonTester : Singleton<object>
+        {
+            private readonly Task<object> _onCreateComplete;
+            private readonly Task<object> _onSafeCloseComplete;
+
+            public SingletonTester(Task<object> onCreateComplete, Task<object> onSafeCloseComplete)
+            {
+                _onCreateComplete = onCreateComplete;
+                _onSafeCloseComplete = onSafeCloseComplete;
+            }
+
+            protected override async Task<object> OnCreateAsync(TimeSpan timeout)
+            {
+                await _onCreateComplete;
+                return new object();
+            }
+
+            protected override void OnSafeClose(object value)
+            {
+                _onSafeCloseComplete.GetAwaiter().GetResult();
+            }
+        }
+
+        private T GetInternalProperty<T>(object from, string propertyName)
+          where T : class
+        {
+            var prop = from.GetType().GetProperty(propertyName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            return prop.GetValue(from) as T;
+        }
+    }
+}


### PR DESCRIPTION
See Issue = #172

**Issue Overview**
When using the singleton class, running GetOrCreateAsync() & CloseAsync() in a particular order, the singleton will end up disposed but with Value remaining populated.

This mainly causes an issue because it is the backing for FaultTolerantAmqpObject<T>. So, a concurrent open/close may cause an amqpobject that we would expect to be closed to remain opened in the background. I believe that is causing this issue I opened in the Azure SDK https://github.com/Azure/azure-sdk-for-net/issues/16994

**Issue Reproduction**
The unit test in this PR contains a reproduction directly against the singleton class.

This project reproduces the issue directly using the FaultTolerantAmqpObject class https://github.com/paulsavides/ServiceBusTesting/tree/b3a5df45c67af84a816ec935d5b6bb749d915b80/ReproAmqp

When using the changes I have made in this PR, have confirmed the issues are fixed.

**Issue Fix**
Generally just adding back a bit of code that was removed in this commit 8366a43

After actually opening the object, just add the following check:
```csharp
if (this.disposed && this.TryRemove())
{
    OnSafeClose(value);
}
```

I briefly considered throwing an ObjectDisposedException here, however, the task result has already been set at this point so setting an exception on the task completion source would not work. Additionally, moving the IsDisposed check before the OnCreate() or SetResult would leave in a race condition so, without introducing additional locking we're stuck just returning a closed object here.

Also added a TryRemove() around both places we may call OnSafeClose(). This is just to try and ensure only one thread will actually call the remove.

Please let me know if you require any changes here, if this is the complete wrong approach or if I have completely misdiagnosed the issue.

---
Thank you for taking a look,
Paul Savides