### PR TITLE
Expose data segment without having to box

### DIFF
--- a/src/AmqpMessage.cs
+++ b/src/AmqpMessage.cs
@@ -814,7 +814,7 @@ namespace Microsoft.Azure.Amqp
 
         /// <summary>
         /// Allow updates in mutalble sections.
-        /// Note: currently this is only used by relay. 
+        /// Note: currently this is only used by relay.
         /// </summary>
         sealed class AmqpClonedMessage : AmqpSectionMessage
         {
@@ -953,7 +953,7 @@ namespace Microsoft.Azure.Amqp
                 {
                     new Data()
                     {
-                        Value = new ArraySegment<byte>(buffer.Buffer, pos, length),
+                        Segment = new ArraySegment<byte>(buffer.Buffer, pos, length),
                         Offset = pos,
                         Length = length
                     }

--- a/src/Framing/AmqpDescribed.cs
+++ b/src/Framing/AmqpDescribed.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Amqp.Framing
         /// <summary>
         /// Gets or sets the value.
         /// </summary>
-        public object Value
+        public virtual object Value
         {
             get;
             set;

--- a/src/Framing/Data.cs
+++ b/src/Framing/Data.cs
@@ -23,19 +23,31 @@ namespace Microsoft.Azure.Amqp.Framing
         {
         }
 
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        public ArraySegment<byte> Segment { get; set; }
+
+        /// <inheritdoc />
+        public override object Value
+        {
+            get { return Segment; }
+            set { Segment = (ArraySegment<byte>) value; }
+        }
+
         internal override int GetValueEncodeSize()
         {
-            return BinaryEncoding.GetEncodeSize((ArraySegment<byte>)this.Value);
+            return BinaryEncoding.GetEncodeSize(this.Segment);
         }
 
         internal override void EncodeValue(ByteBuffer buffer)
         {
-            BinaryEncoding.Encode((ArraySegment<byte>)this.Value, buffer);
+            BinaryEncoding.Encode(this.Segment, buffer);
         }
 
         internal override void DecodeValue(ByteBuffer buffer)
         {
-            this.Value = BinaryEncoding.Decode(buffer, 0);
+            this.Segment = BinaryEncoding.Decode(buffer, 0);
         }
 
         /// <summary>

--- a/test/Common/AmqpUtils.cs
+++ b/test/Common/AmqpUtils.cs
@@ -137,7 +137,7 @@ namespace Test.Microsoft.Azure.Amqp
 
         public static AmqpMessage CreateMessage(ArraySegment<byte> binaryData)
         {
-            return AmqpMessage.Create(new Data[] { new Data() { Value = binaryData } });
+            return AmqpMessage.Create(new Data[] { new Data() { Segment = binaryData } });
         }
 
         public static ByteBuffer GetBuffer(this AmqpMessage message)
@@ -261,7 +261,7 @@ namespace Test.Microsoft.Azure.Amqp
                 }
             }
 
-            throw new ArgumentException("No certificate can be found using the find value.");            
+            throw new ArgumentException("No certificate can be found using the find value.");
         }
 
         static void DumpAmqpData(ByteBuffer buffer, int indent)

--- a/test/TestCases/AmqpLinkTests.cs
+++ b/test/TestCases/AmqpLinkTests.cs
@@ -39,10 +39,10 @@ namespace Test.Microsoft.Azure.Amqp
             const int messageCount = 10;
             string queue = "AmqpLinkSyncSendReceiveTestQueue";
             broker.AddQueue(queue);
-            
+
             this.SendReceive(queue, messageCount, true, true, false);
         }
-        
+
         [Fact]
         public void AmqpLinkAsyncSendReceiveTest()
         {
@@ -250,7 +250,7 @@ namespace Test.Microsoft.Azure.Amqp
             sLink.Open();
 
             string data = new string('a', 128 * 1024);
-            AmqpMessage message = AmqpMessage.Create(new Data() { Value = new ArraySegment<byte>(System.Text.Encoding.UTF8.GetBytes(data)) });
+            AmqpMessage message = AmqpMessage.Create(new Data() { Segment = new ArraySegment<byte>(System.Text.Encoding.UTF8.GetBytes(data)) });
             message.Header.Priority = 1;
             message.DeliveryAnnotations.Map.Add("test", "da");
             message.MessageAnnotations.Map.Add("test", "ma");

--- a/test/TestCases/AmqpMessageTests.cs
+++ b/test/TestCases/AmqpMessageTests.cs
@@ -49,10 +49,10 @@
             RunSerializationTest(message);
 
             // data message
-            message = AmqpMessage.Create(new Data() { Value = new ArraySegment<byte>(new byte[60]) });
+            message = AmqpMessage.Create(new Data() { Segment = new ArraySegment<byte>(new byte[60]) });
             RunSerializationTest(message);
 
-            message = AmqpMessage.Create(new Data[] { new Data() { Value = new ArraySegment<byte>(new byte[60]) }, new Data() { Value = new ArraySegment<byte>(new byte[44]) } });
+            message = AmqpMessage.Create(new Data[] { new Data() { Segment = new ArraySegment<byte>(new byte[60]) }, new Data() { Value = new ArraySegment<byte>(new byte[44]) } });
             AddSection(message, SectionFlag.Header | SectionFlag.ApplicationProperties);
             RunSerializationTest(message);
 
@@ -98,7 +98,7 @@
         {
             var messages = new AmqpMessage[]
             {
-                AmqpMessage.Create(new Data() { Value = new ArraySegment<byte>(new byte[60]) }),
+                AmqpMessage.Create(new Data() { Segment = new ArraySegment<byte>(new byte[60]) }),
                 AmqpMessage.Create(new MemoryStream(new byte[1000]), true)
             };
 
@@ -299,7 +299,7 @@
                         Assert.Equal(enumerator1.Current.List.Count, enumerator2.Current.List.Count);
                         for(int i = 0; i < enumerator1.Current.List.Count; i++)
                         {
-                            Assert.Equal(enumerator1.Current.List[i], enumerator2.Current.List[i]); 
+                            Assert.Equal(enumerator1.Current.List[i], enumerator2.Current.List[i]);
                         }
                     }
                 }


### PR DESCRIPTION
With this change, it is possible to access the data segment directly without having to box the array segment struct. To make things backward compatible I had to make the base class Value property virtual. 