### PR TITLE
Array Encoding/Decoding performance improvements (continued)

### DIFF
--- a/src/AmqpCodec.cs
+++ b/src/AmqpCodec.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Amqp
         /// <returns>Encode size in bytes of the array.</returns>
         public static int GetArrayEncodeSize<T>(T[] value)
         {
-            return ArrayEncoding.GetEncodeSize(value);
+            return ArrayEncoding.GetEncodeSize<T>(value);
         }
 
         /// <summary>
@@ -580,7 +580,7 @@ namespace Microsoft.Azure.Amqp
         /// <param name="buffer">The destination buffer.</param>
         public static void EncodeArray<T>(T[] data, ByteBuffer buffer)
         {
-            ArrayEncoding.Encode(data, buffer);
+            ArrayEncoding.Encode<T>(data, buffer);
         }
 
         /// <summary>

--- a/src/ByteBuffer.cs
+++ b/src/ByteBuffer.cs
@@ -421,6 +421,16 @@ namespace Microsoft.Azure.Amqp
             }
         }
 
+        internal ReadOnlySpan<byte> GetReadSpan()
+        {
+            return this.buffer.AsSpan(this.Offset, this.Length);
+        }
+
+        internal Span<byte> GetWriteSpan()
+        {
+            return this.buffer.AsSpan(this.WritePos, this.Size);
+        }
+
         [Conditional("DEBUG")]
         internal void AssertReferences(int value)
         {

--- a/src/Encoding/AmqpBitConverter.cs
+++ b/src/Encoding/AmqpBitConverter.cs
@@ -142,6 +142,21 @@ namespace Microsoft.Azure.Amqp.Encoding
             return data;
         }
 
+        internal static uint ReadUInt(ReadOnlySpan<byte> buffer, int offset, int count)
+        {
+            Validate(count, FixedWidth.UInt);
+            uint data;
+            fixed (byte* p = &buffer[offset])
+            {
+                byte* d = (byte*)&data;
+                d[0] = p[3];
+                d[1] = p[2];
+                d[2] = p[1];
+                d[3] = p[0];
+            }
+            return data;
+        }
+
         /// <summary>
         /// Reads a 64-bit signed number from a buffer.
         /// </summary>
@@ -298,6 +313,13 @@ namespace Microsoft.Azure.Amqp.Encoding
         {
             buffer.Validate(false, count);
             Buffer.BlockCopy(buffer.Buffer, buffer.Offset, data, offset, count);
+            buffer.Complete(count);
+        }
+
+        internal static void ReadBytes(ByteBuffer buffer, Span<byte> data, int offset, int count)
+        {
+            buffer.Validate(false, count);
+            buffer.GetReadSpan().Slice(offset, count).CopyTo(data);
             buffer.Complete(count);
         }
 
@@ -557,6 +579,13 @@ namespace Microsoft.Azure.Amqp.Encoding
         {
             buffer.Validate(true, count);
             Buffer.BlockCopy(data, offset, buffer.Buffer, buffer.WritePos, count);
+            buffer.Append(count);
+        }
+
+        internal static void WriteBytes(ByteBuffer buffer, ReadOnlySpan<byte> data, int count)
+        {
+            buffer.Validate(true, count);
+            data.CopyTo(buffer.GetWriteSpan());
             buffer.Append(count);
         }
 

--- a/src/Encoding/AmqpBitConverter.cs
+++ b/src/Encoding/AmqpBitConverter.cs
@@ -582,10 +582,10 @@ namespace Microsoft.Azure.Amqp.Encoding
             buffer.Append(count);
         }
 
-        internal static void WriteBytes(ByteBuffer buffer, ReadOnlySpan<byte> data, int count)
+        internal static void WriteBytes(ByteBuffer buffer, ReadOnlySpan<byte> data, int offset, int count)
         {
             buffer.Validate(true, count);
-            data.CopyTo(buffer.GetWriteSpan());
+            data.CopyTo(buffer.GetWriteSpan().Slice(offset, count));
             buffer.Append(count);
         }
 

--- a/src/Encoding/ArrayEncoding.cs
+++ b/src/Encoding/ArrayEncoding.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             EncodingBase encoding = AmqpEncoding.GetEncoding(formatCode);
             if (encoding is PrimitiveEncoding<T> primitiveEncoding)
             {
-                return (T[])primitiveEncoding.DecodeArray(buffer, count, formatCode);
+                return primitiveEncoding.DecodeArray(buffer, count, formatCode);
             }
 
             object descriptor = null;

--- a/src/Encoding/BinaryEncoding.cs
+++ b/src/Encoding/BinaryEncoding.cs
@@ -4,8 +4,9 @@
 namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
+    using System.Collections.Generic;
 
-    sealed class BinaryEncoding : EncodingBase
+    sealed class BinaryEncoding : PrimitiveEncoding<ArraySegment<byte>>
     {
         public BinaryEncoding()
             : base(FormatCode.Binary32)
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.Amqp.Encoding
                     AmqpBitConverter.WriteUInt(buffer, (uint)value.Count);
                 }
 
-                AmqpBitConverter.WriteBytes(buffer, value.Array, value.Offset, value.Count);
+                AmqpBitConverter.WriteBytes(buffer, value, value.Offset, value.Count);
             }
         }
 
@@ -61,23 +62,21 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 return AmqpConstants.EmptyBinary;
             }
+
+            ArraySegment<byte> value;
+            if (copy)
+            {
+                byte[] valueBuffer = new byte[count];
+                Buffer.BlockCopy(buffer.Buffer, buffer.Offset, valueBuffer, 0, count);
+                value = new ArraySegment<byte>(valueBuffer, 0, count);
+            }
             else
             {
-                ArraySegment<byte> value;
-                if (copy)
-                {
-                    byte[] valueBuffer = new byte[count];
-                    Buffer.BlockCopy(buffer.Buffer, buffer.Offset, valueBuffer, 0, count);
-                    value = new ArraySegment<byte>(valueBuffer, 0, count);
-                }
-                else
-                {
-                    value = new ArraySegment<byte>(buffer.Buffer, buffer.Offset, count);
-                }
-
-                buffer.Complete(count);
-                return value;
+                value = new ArraySegment<byte>(buffer.Buffer, buffer.Offset, count);
             }
+
+            buffer.Complete(count);
+            return value;
         }
 
         public override int GetObjectEncodeSize(object value, bool arrayEncoding)
@@ -86,10 +85,8 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 return FixedWidth.UInt + ((ArraySegment<byte>)value).Count;
             }
-            else
-            {
-                return BinaryEncoding.GetEncodeSize((ArraySegment<byte>)value);
-            }
+
+            return BinaryEncoding.GetEncodeSize((ArraySegment<byte>)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -98,7 +95,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 ArraySegment<byte> binaryValue = (ArraySegment<byte>)value;
                 AmqpBitConverter.WriteUInt(buffer, (uint)binaryValue.Count);
-                AmqpBitConverter.WriteBytes(buffer, binaryValue.Array, binaryValue.Offset, binaryValue.Count);
+                AmqpBitConverter.WriteBytes(buffer, binaryValue, binaryValue.Offset, binaryValue.Count);
             }
             else
             {
@@ -109,6 +106,55 @@ namespace Microsoft.Azure.Amqp.Encoding
         public override object DecodeObject(ByteBuffer buffer, FormatCode formatCode)
         {
             return BinaryEncoding.Decode(buffer, formatCode, false);
+        }
+
+        public override int GetArrayEncodeSize(IList<ArraySegment<byte>> value)
+        {
+            int size = 0;
+            for (int i = 0; i < value.Count; i++)
+            {
+                size += AmqpEncoding.GetEncodeWidthBySize(value[i].Count);
+            }
+            return size;
+        }
+
+        public override void EncodeArray(IList<ArraySegment<byte>> value, ByteBuffer buffer)
+        {
+            if (value is ArraySegment<byte>[] arraySegments)
+            {
+                // fast-path for ArraySegment<byte>[] so the bounds checks can be elided
+                for (int i = 0; i < arraySegments.Length; i++)
+                {
+                    var segment = arraySegments[i];
+                    AmqpBitConverter.WriteUInt(buffer, (uint)segment.Count);
+                    AmqpBitConverter.WriteBytes(buffer, segment, segment.Offset, segment.Count);
+                }
+            }
+            else
+            {
+                IReadOnlyList<ArraySegment<byte>> listValue = (IReadOnlyList<ArraySegment<byte>>)value;
+                for (int i = 0; i < listValue.Count; i++)
+                {
+                    var segment = listValue[i];
+                    AmqpBitConverter.WriteUInt(buffer, (uint)segment.Count);
+                    AmqpBitConverter.WriteBytes(buffer, segment, segment.Offset, segment.Count);
+                }
+            }
+        }
+
+        public override ArraySegment<byte>[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        {
+            ArraySegment<byte>[] array = new ArraySegment<byte>[count];
+            for (int i = 0; i < count; ++i)
+            {
+                AmqpEncoding.ReadCount(buffer, formatCode, FormatCode.Binary8, FormatCode.Binary32, out count);
+                // always copy?
+                byte[] valueBuffer = new byte[count];
+                var arraySegment = new ArraySegment<byte>(valueBuffer, 0, count);
+                AmqpBitConverter.ReadBytes(buffer, arraySegment, 0, count);
+                array[i] = arraySegment;
+            }
+            return array;
         }
     }
 }

--- a/src/Encoding/ByteEncoding.cs
+++ b/src/Encoding/ByteEncoding.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
-    using System.Buffers.Binary;
     using System.Collections.Generic;
 
     sealed class ByteEncoding : PrimitiveEncoding<sbyte>

--- a/src/Encoding/DecimalEncoding.cs
+++ b/src/Encoding/DecimalEncoding.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             bytes[14] = p[1];
             bytes[15] = p[0];
 
-            AmqpBitConverter.WriteBytes(buffer, bytes, bytes.Length);
+            AmqpBitConverter.WriteBytes(buffer, bytes, 0, bytes.Length);
         }
 
         static decimal DecodeValue(ByteBuffer buffer, FormatCode formatCode)
@@ -271,8 +271,6 @@ namespace Microsoft.Azure.Amqp.Encoding
                     EncodeValue(listValue[i], buffer);
                 }
             }
-
-            buffer.Append(byteCount);
         }
 
         public override decimal[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
@@ -285,8 +283,6 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 array[i] = DecodeValue(buffer, formatCode);
             }
-
-            buffer.Complete(byteCount);
 
             return array;
         }

--- a/src/Encoding/DecimalEncoding.cs
+++ b/src/Encoding/DecimalEncoding.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
-    using System.Buffers.Binary;
     using System.Collections.Generic;
 
     /// <summary>

--- a/src/Encoding/IntEncoding.cs
+++ b/src/Encoding/IntEncoding.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
     using System.Buffers.Binary;
-    using System.Collections;
     using System.Collections.Generic;
 
     sealed class IntEncoding : PrimitiveEncoding<int>
@@ -23,10 +22,8 @@ namespace Microsoft.Azure.Amqp.Encoding
                     FixedWidth.IntEncoded :
                     FixedWidth.ByteEncoded;
             }
-            else
-            {
-                return FixedWidth.NullEncoded;
-            }
+
+            return FixedWidth.NullEncoded;
         }
 
         public static void Encode(int? value, ByteBuffer buffer)
@@ -69,10 +66,8 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 return FixedWidth.Int;
             }
-            else
-            {
-                return IntEncoding.GetEncodeSize((int)value);
-            }
+
+            return GetEncodeSize((int)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -83,13 +78,13 @@ namespace Microsoft.Azure.Amqp.Encoding
             }
             else
             {
-                IntEncoding.Encode((int)value, buffer);
+                Encode((int)value, buffer);
             }
         }
 
         public override object DecodeObject(ByteBuffer buffer, FormatCode formatCode)
         {
-            return IntEncoding.Decode(buffer, formatCode);
+            return Decode(buffer, formatCode);
         }
 
         public override int GetArrayEncodeSize(IList<int> value)
@@ -102,6 +97,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             int byteCount = FixedWidth.Int * value.Count;
 
             buffer.Validate(write: true, byteCount);
+
             Span<byte> destination = buffer.GetWriteSpan();
 
             if (value is int[] intArray)
@@ -124,10 +120,9 @@ namespace Microsoft.Azure.Amqp.Encoding
             buffer.Append(byteCount);
         }
 
-        public override Array DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        public override int[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
         {
             int byteCount = FixedWidth.Int * count;
-
             buffer.Validate(write: false, byteCount);
             ReadOnlySpan<byte> source = buffer.GetReadSpan();
 

--- a/src/Encoding/IntEncoding.cs
+++ b/src/Encoding/IntEncoding.cs
@@ -62,12 +62,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
         public override int GetObjectEncodeSize(object value, bool arrayEncoding)
         {
-            if (arrayEncoding)
-            {
-                return FixedWidth.Int;
-            }
-
-            return GetEncodeSize((int)value);
+            return arrayEncoding ? FixedWidth.Int : GetEncodeSize((int)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)

--- a/src/Encoding/IntEncoding.cs
+++ b/src/Encoding/IntEncoding.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Amqp.Encoding
     using System.Collections;
     using System.Collections.Generic;
 
-    sealed class IntEncoding : PrimitiveEncoding
+    sealed class IntEncoding : PrimitiveEncoding<int>
     {
         public IntEncoding()
             : base(FormatCode.Int)
@@ -92,18 +92,18 @@ namespace Microsoft.Azure.Amqp.Encoding
             return IntEncoding.Decode(buffer, formatCode);
         }
 
-        public override int GetArrayEncodeSize(IList value)
+        public override int GetArrayEncodeSize(IList<int> value)
         {
             return FixedWidth.Int * value.Count;
         }
 
-        public override void EncodeArray(IList value, ByteBuffer buffer)
+        public override void EncodeArray(IList<int> value, ByteBuffer buffer)
         {
             int byteCount = FixedWidth.Int * value.Count;
 
             buffer.Validate(write: true, byteCount);
             Span<byte> destination = buffer.GetWriteSpan();
-            
+
             if (value is int[] intArray)
             {
                 // fast-path for int[] so the bounds checks can be elided
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
             buffer.Validate(write: false, byteCount);
             ReadOnlySpan<byte> source = buffer.GetReadSpan();
-            
+
             int[] array = new int[count];
             for (int i = 0; i < count; ++i)
             {

--- a/src/Encoding/PrimitiveEncoding.cs
+++ b/src/Encoding/PrimitiveEncoding.cs
@@ -4,18 +4,18 @@
 namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
-    using System.Collections;
+    using System.Collections.Generic;
 
-    abstract class PrimitiveEncoding : EncodingBase
+    abstract class PrimitiveEncoding<T> : EncodingBase
     {
         protected PrimitiveEncoding(FormatCode formatCode)
             : base(formatCode)
         {
         }
 
-        public abstract int GetArrayEncodeSize(IList value);
+        public abstract int GetArrayEncodeSize(IList<T> value);
 
-        public abstract void EncodeArray(IList value, ByteBuffer buffer);
+        public abstract void EncodeArray(IList<T> value, ByteBuffer buffer);
         public abstract Array DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode);
     }
 }

--- a/src/Encoding/PrimitiveEncoding.cs
+++ b/src/Encoding/PrimitiveEncoding.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.Amqp.Encoding
         public abstract int GetArrayEncodeSize(IList<T> value);
 
         public abstract void EncodeArray(IList<T> value, ByteBuffer buffer);
-        public abstract Array DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode);
+        public abstract T[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode);
     }
 }

--- a/src/Encoding/PrimitiveEncoding.cs
+++ b/src/Encoding/PrimitiveEncoding.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Azure.Amqp.Encoding
 {
-    using System;
     using System.Collections.Generic;
 
     abstract class PrimitiveEncoding<T> : EncodingBase

--- a/src/Encoding/PrimitiveEncoding.cs
+++ b/src/Encoding/PrimitiveEncoding.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Amqp.Encoding
+{
+    using System;
+    using System.Collections;
+
+    abstract class PrimitiveEncoding : EncodingBase
+    {
+        protected PrimitiveEncoding(FormatCode formatCode)
+            : base(formatCode)
+        {
+        }
+
+        public abstract int GetArrayEncodeSize(IList value);
+
+        public abstract void EncodeArray(IList value, ByteBuffer buffer);
+        public abstract Array DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode);
+    }
+}

--- a/src/Encoding/ShortEncoding.cs
+++ b/src/Encoding/ShortEncoding.cs
@@ -40,14 +40,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
         public override int GetObjectEncodeSize(object value, bool arrayEncoding)
         {
-            if (arrayEncoding)
-            {
-                return FixedWidth.Short;
-            }
-            else
-            {
-                return ShortEncoding.GetEncodeSize((short)value);
-            }
+            return arrayEncoding ? FixedWidth.Short : ShortEncoding.GetEncodeSize((short)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)

--- a/src/Encoding/ShortEncoding.cs
+++ b/src/Encoding/ShortEncoding.cs
@@ -3,7 +3,11 @@
 
 namespace Microsoft.Azure.Amqp.Encoding
 {
-    sealed class ShortEncoding : EncodingBase
+    using System;
+    using System.Buffers.Binary;
+    using System.Collections.Generic;
+
+    sealed class ShortEncoding : PrimitiveEncoding<short>
     {
         public ShortEncoding()
             : base(FormatCode.Short)
@@ -58,6 +62,56 @@ namespace Microsoft.Azure.Amqp.Encoding
         public override object DecodeObject(ByteBuffer buffer, FormatCode formatCode)
         {
             return ShortEncoding.Decode(buffer, formatCode);
+        }
+
+        public override int GetArrayEncodeSize(IList<short> value)
+        {
+            return FixedWidth.Short * value.Count;
+        }
+
+        public override void EncodeArray(IList<short> value, ByteBuffer buffer)
+        {
+            int byteCount = FixedWidth.Short * value.Count;
+
+            buffer.Validate(write: true, byteCount);
+
+            Span<byte> destination = buffer.GetWriteSpan();
+
+            if (value is short[] shortArray)
+            {
+                // fast-path for ushort[] so the bounds checks can be elided
+                for (int i = 0; i < shortArray.Length; i++)
+                {
+                    BinaryPrimitives.WriteInt16BigEndian(destination.Slice(FixedWidth.Short * i), shortArray[i]);
+                }
+            }
+            else
+            {
+                IReadOnlyList<short> listValue = (IReadOnlyList<short>)value;
+                for (int i = 0; i < listValue.Count; i++)
+                {
+                    BinaryPrimitives.WriteInt16BigEndian(destination.Slice(FixedWidth.Short * i), listValue[i]);
+                }
+            }
+
+            buffer.Append(byteCount);
+        }
+
+        public override short[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        {
+            int byteCount = FixedWidth.UShort * count;
+            buffer.Validate(write: false, byteCount);
+            ReadOnlySpan<byte> source = buffer.GetReadSpan();
+
+            short[] array = new short[count];
+            for (int i = 0; i < count; ++i)
+            {
+                array[i] = BinaryPrimitives.ReadInt16BigEndian(source.Slice(FixedWidth.Short * i));
+            }
+
+            buffer.Complete(byteCount);
+
+            return array;
         }
     }
 }

--- a/src/Encoding/StringEncoding.cs
+++ b/src/Encoding/StringEncoding.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Azure.Amqp.Encoding
 {
+    using System;
     using System.Text;
 
     sealed class StringEncoding : EncodingBase
@@ -31,7 +32,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             }
             else
             {
-                byte[] encodedData = Encoding.UTF8.GetBytes(value);
+                ReadOnlySpan<byte> encodedData = Encoding.UTF8.GetBytes(value);
                 int encodeWidth = AmqpEncoding.GetEncodeWidthBySize(encodedData.Length);
                 AmqpBitConverter.WriteUByte(buffer, encodeWidth == FixedWidth.UByte ? FormatCode.String8Utf8 : FormatCode.String32Utf8);
                 StringEncoding.Encode(encodedData, encodeWidth, buffer);
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
             if (formatCode == FormatCode.String8Utf8)
             {
-                count = (int)AmqpBitConverter.ReadUByte(buffer);
+                count = AmqpBitConverter.ReadUByte(buffer);
                 encoding = Encoding.UTF8;
             }
             else if (formatCode == FormatCode.String32Utf8)
@@ -75,10 +76,8 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 return FixedWidth.UInt + Encoding.UTF8.GetByteCount((string)value);
             }
-            else
-            {
-                return StringEncoding.GetEncodeSize((string)value);
-            }
+
+            return StringEncoding.GetEncodeSize((string)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -98,7 +97,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             return StringEncoding.Decode(buffer, formatCode);
         }
 
-        static void Encode(byte[] encodedData, int width, ByteBuffer buffer)
+        static void Encode(ReadOnlySpan<byte> encodedData, int width, ByteBuffer buffer)
         {
             if (width == FixedWidth.UByte)
             {

--- a/src/Encoding/StringEncoding.cs
+++ b/src/Encoding/StringEncoding.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Azure.Amqp.Encoding
         {
             if (arrayEncoding)
             {
-                StringEncoding.Encode(Encoding.UTF8.GetBytes((string)value), FixedWidth.UInt, buffer);
+                var encodedData = Encoding.UTF8.GetBytes((string)value);
+                StringEncoding.Encode(encodedData, FixedWidth.UInt, buffer);
             }
             else
             {

--- a/src/Encoding/SymbolEncoding.cs
+++ b/src/Encoding/SymbolEncoding.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Amqp.Encoding
     using System.Collections.Generic;
     using System.Text;
 
-    sealed class SymbolEncoding : PrimitiveEncoding
+    sealed class SymbolEncoding : PrimitiveEncoding<AmqpSymbol>
     {
         public SymbolEncoding()
             : base(FormatCode.Symbol32)
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             AmqpBitConverter.WriteBytes(buffer, encodedData, 0, encodedDataLength);
         }
 
-        public override int GetArrayEncodeSize(IList value)
+        public override int GetArrayEncodeSize(IList<AmqpSymbol> value)
         {
             IReadOnlyList<AmqpSymbol> listValue = (IReadOnlyList<AmqpSymbol>)value;
 
@@ -122,12 +122,10 @@ namespace Microsoft.Azure.Amqp.Encoding
             return size;
         }
 
-        public override void EncodeArray(IList value, ByteBuffer buffer)
+        public override void EncodeArray(IList<AmqpSymbol> value, ByteBuffer buffer)
         {
-            IReadOnlyList<AmqpSymbol> listValue = (IReadOnlyList<AmqpSymbol>)value;
-
             byte[] tempBuffer = null;
-            foreach (AmqpSymbol item in listValue)
+            foreach (AmqpSymbol item in value)
             {
                 string s = item.Value;
                 int byteCount = Encoding.ASCII.GetByteCount(s);

--- a/src/Encoding/SymbolEncoding.cs
+++ b/src/Encoding/SymbolEncoding.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
     using System.Buffers;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Text;
 
@@ -40,7 +39,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             }
             else
             {
-                byte[] encodedData = Encoding.ASCII.GetBytes(value.Value);
+                ReadOnlySpan<byte> encodedData = Encoding.ASCII.GetBytes(value.Value);
                 int encodeWidth = AmqpEncoding.GetEncodeWidthBySize(encodedData.Length);
                 AmqpBitConverter.WriteUByte(buffer, encodeWidth == FixedWidth.UByte ? FormatCode.Symbol8 : FormatCode.Symbol32);
                 SymbolEncoding.Encode(encodedData, encodeWidth, buffer);
@@ -88,23 +87,18 @@ namespace Microsoft.Azure.Amqp.Encoding
             return SymbolEncoding.Decode(buffer, formatCode);
         }
 
-        static void Encode(byte[] encodedData, int width, ByteBuffer buffer)
-        {
-            Encode(encodedData, encodedData.Length, width, buffer);
-        }
-
-        static void Encode(byte[] encodedData, int encodedDataLength, int width, ByteBuffer buffer)
+        static void Encode(ReadOnlySpan<byte> encodedData, int width, ByteBuffer buffer)
         {
             if (width == FixedWidth.UByte)
             {
-                AmqpBitConverter.WriteUByte(buffer, (byte)encodedDataLength);
+                AmqpBitConverter.WriteUByte(buffer, (byte)encodedData.Length);
             }
             else
             {
-                AmqpBitConverter.WriteUInt(buffer, (uint)encodedDataLength);
+                AmqpBitConverter.WriteUInt(buffer, (uint)encodedData.Length);
             }
 
-            AmqpBitConverter.WriteBytes(buffer, encodedData, 0, encodedDataLength);
+            AmqpBitConverter.WriteBytes(buffer, encodedData, 0, encodedData.Length);
         }
 
         public override int GetArrayEncodeSize(IList<AmqpSymbol> value)

--- a/src/Encoding/SymbolEncoding.cs
+++ b/src/Encoding/SymbolEncoding.cs
@@ -54,8 +54,7 @@ namespace Microsoft.Azure.Amqp.Encoding
                 return new AmqpSymbol();
             }
 
-            int count;
-            AmqpEncoding.ReadCount(buffer, formatCode, FormatCode.Symbol8, FormatCode.Symbol32, out count);
+            AmqpEncoding.ReadCount(buffer, formatCode, FormatCode.Symbol8, FormatCode.Symbol32, out var count);
             string value = Encoding.ASCII.GetString(buffer.Buffer, buffer.Offset, count);
             buffer.Complete(count);
 
@@ -68,10 +67,8 @@ namespace Microsoft.Azure.Amqp.Encoding
             {
                 return FixedWidth.UInt + Encoding.ASCII.GetByteCount(((AmqpSymbol)value).Value);
             }
-            else
-            {
-                return SymbolEncoding.GetEncodeSize((AmqpSymbol)value);
-            }
+
+            return SymbolEncoding.GetEncodeSize((AmqpSymbol)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -115,11 +112,11 @@ namespace Microsoft.Azure.Amqp.Encoding
             IReadOnlyList<AmqpSymbol> listValue = (IReadOnlyList<AmqpSymbol>)value;
 
             int size = 0;
-            foreach (AmqpSymbol item in listValue)
+            for (var index = 0; index < listValue.Count; index++)
             {
+                AmqpSymbol item = listValue[index];
                 size += Encoding.ASCII.GetByteCount(item.Value);
             }
-
             return size;
         }
 
@@ -136,7 +133,7 @@ namespace Microsoft.Azure.Amqp.Encoding
                 var tempBuffer = pool.Rent(byteCount);
                 int encodedByteCount = Encoding.ASCII.GetBytes(stringValue, 0, stringValue.Length, tempBuffer, 0);
                 Encode(tempBuffer, encodedByteCount, FixedWidth.UInt, buffer);
-                
+
                 pool.Return(tempBuffer);
             }
         }

--- a/src/Encoding/SymbolEncoding.cs
+++ b/src/Encoding/SymbolEncoding.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Amqp.Encoding
             }
         }
 
-        public override Array DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        public override AmqpSymbol[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
         {
             AmqpSymbol[] symbolArray = new AmqpSymbol[count];
             for (int i = 0; i < count; ++i)

--- a/src/Encoding/UByteEncoding.cs
+++ b/src/Encoding/UByteEncoding.cs
@@ -3,7 +3,10 @@
 
 namespace Microsoft.Azure.Amqp.Encoding
 {
-    sealed class UByteEncoding : EncodingBase
+    using System;
+    using System.Collections.Generic;
+
+    sealed class UByteEncoding : PrimitiveEncoding<byte>
     {
         public UByteEncoding()
             : base(FormatCode.UByte)
@@ -40,14 +43,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
         public override int GetObjectEncodeSize(object value, bool arrayEncoding)
         {
-            if (arrayEncoding)
-            {
-                return FixedWidth.UByte;
-            }
-            else
-            {
-                return UByteEncoding.GetEncodeSize((byte)value);
-            }
+            return arrayEncoding ? FixedWidth.UByte : UByteEncoding.GetEncodeSize((byte)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -65,6 +61,48 @@ namespace Microsoft.Azure.Amqp.Encoding
         public override object DecodeObject(ByteBuffer buffer, FormatCode formatCode)
         {
             return UByteEncoding.Decode(buffer, formatCode);
+        }
+
+        public override int GetArrayEncodeSize(IList<byte> value)
+        {
+            return FixedWidth.UByte * value.Count;
+        }
+
+        public override void EncodeArray(IList<byte> value, ByteBuffer buffer)
+        {
+            int byteCount = FixedWidth.UByte * value.Count;
+
+            buffer.Validate(write: true, byteCount);
+
+            Span<byte> destination = buffer.GetWriteSpan();
+
+            if (value is byte[] byteArray)
+            {
+                // fast-path for byte[] so the bounds checks can be elided
+                byteArray.AsSpan().CopyTo(destination);
+            }
+            else
+            {
+                IReadOnlyList<byte> listValue = (IReadOnlyList<byte>)value;
+                for (int i = 0; i < listValue.Count; i++)
+                {
+                    destination.Slice(FixedWidth.UByte * i)[0] = listValue[i];
+                }
+            }
+
+            buffer.Append(byteCount);
+        }
+
+        public override byte[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        {
+            int byteCount = FixedWidth.UByte * count;
+            buffer.Validate(write: false, byteCount);
+            ReadOnlySpan<byte> source = buffer.GetReadSpan();
+
+            byte[] array = new byte[count];
+            source.CopyTo(array);
+            buffer.Complete(byteCount);
+            return array;
         }
     }
 }

--- a/src/Encoding/UShortEncoding.cs
+++ b/src/Encoding/UShortEncoding.cs
@@ -3,7 +3,11 @@
 
 namespace Microsoft.Azure.Amqp.Encoding
 {
-    sealed class UShortEncoding : EncodingBase
+    using System;
+    using System.Buffers.Binary;
+    using System.Collections.Generic;
+
+    sealed class UShortEncoding : PrimitiveEncoding<ushort>
     {
         public UShortEncoding()
             : base(FormatCode.UShort)
@@ -40,14 +44,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
         public override int GetObjectEncodeSize(object value, bool arrayEncoding)
         {
-            if (arrayEncoding)
-            {
-                return FixedWidth.UShort;
-            }
-            else
-            {
-                return UShortEncoding.GetEncodeSize((ushort)value);
-            }
+            return arrayEncoding ? FixedWidth.UShort : UShortEncoding.GetEncodeSize((ushort)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -65,6 +62,56 @@ namespace Microsoft.Azure.Amqp.Encoding
         public override object DecodeObject(ByteBuffer buffer, FormatCode formatCode)
         {
             return UShortEncoding.Decode(buffer, formatCode);
+        }
+
+        public override int GetArrayEncodeSize(IList<ushort> value)
+        {
+            return FixedWidth.UShort * value.Count;
+        }
+
+        public override void EncodeArray(IList<ushort> value, ByteBuffer buffer)
+        {
+            int byteCount = FixedWidth.UShort * value.Count;
+
+            buffer.Validate(write: true, byteCount);
+
+            Span<byte> destination = buffer.GetWriteSpan();
+
+            if (value is ushort[] ushortArray)
+            {
+                // fast-path for ushort[] so the bounds checks can be elided
+                for (int i = 0; i < ushortArray.Length; i++)
+                {
+                    BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(FixedWidth.UShort * i), ushortArray[i]);
+                }
+            }
+            else
+            {
+                IReadOnlyList<ushort> listValue = (IReadOnlyList<ushort>)value;
+                for (int i = 0; i < listValue.Count; i++)
+                {
+                    BinaryPrimitives.WriteUInt16BigEndian(destination.Slice(FixedWidth.UShort * i), listValue[i]);
+                }
+            }
+
+            buffer.Append(byteCount);
+        }
+
+        public override ushort[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        {
+            int byteCount = FixedWidth.UShort * count;
+            buffer.Validate(write: false, byteCount);
+            ReadOnlySpan<byte> source = buffer.GetReadSpan();
+
+            ushort[] array = new ushort[count];
+            for (int i = 0; i < count; ++i)
+            {
+                array[i] = BinaryPrimitives.ReadUInt16BigEndian(source.Slice(FixedWidth.UShort * i));
+            }
+
+            buffer.Complete(byteCount);
+
+            return array;
         }
     }
 }

--- a/src/Encoding/UuidEncoding.cs
+++ b/src/Encoding/UuidEncoding.cs
@@ -4,8 +4,9 @@
 namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
+    using System.Collections.Generic;
 
-    sealed class UuidEncoding : EncodingBase
+    sealed class UuidEncoding : PrimitiveEncoding<Guid>
     {
         public UuidEncoding()
             : base(FormatCode.Uuid)
@@ -42,14 +43,7 @@ namespace Microsoft.Azure.Amqp.Encoding
 
         public override int GetObjectEncodeSize(object value, bool arrayEncoding)
         {
-            if (arrayEncoding)
-            {
-                return FixedWidth.Uuid;
-            }
-            else
-            {
-                return UuidEncoding.GetEncodeSize((Guid)value);
-            }
+            return arrayEncoding ? FixedWidth.Uuid : UuidEncoding.GetEncodeSize((Guid)value);
         }
 
         public override void EncodeObject(object value, bool arrayEncoding, ByteBuffer buffer)
@@ -67,6 +61,41 @@ namespace Microsoft.Azure.Amqp.Encoding
         public override object DecodeObject(ByteBuffer buffer, FormatCode formatCode)
         {
             return UuidEncoding.Decode(buffer, formatCode);
+        }
+
+        public override int GetArrayEncodeSize(IList<Guid> value)
+        {
+            return FixedWidth.Uuid * value.Count;
+        }
+
+        public override void EncodeArray(IList<Guid> value, ByteBuffer buffer)
+        {
+            if (value is Guid[] guidArray)
+            {
+                // fast-path for ushort[] so the bounds checks can be elided
+                for (int i = 0; i < guidArray.Length; i++)
+                {
+                    AmqpBitConverter.WriteUuid(buffer, guidArray[i]);
+                }
+            }
+            else
+            {
+                IReadOnlyList<Guid> listValue = (IReadOnlyList<Guid>)value;
+                for (int i = 0; i < listValue.Count; i++)
+                {
+                    AmqpBitConverter.WriteUuid(buffer, listValue[i]);
+                }
+            }
+        }
+
+        public override Guid[] DecodeArray(ByteBuffer buffer, int count, FormatCode formatCode)
+        {
+            Guid[] array = new Guid[count];
+            for (int i = 0; i < count; ++i)
+            {
+                array[i] = AmqpBitConverter.ReadUuid(buffer);
+            }
+            return array;
         }
     }
 }

--- a/src/Framing/Multiple.cs
+++ b/src/Framing/Multiple.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Amqp.Framing
             }
             else
             {
-                return ArrayEncoding.GetEncodeSize(multiple.ToArray());
+                return ArrayEncoding.GetEncodeSize<T>(multiple);
             }
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Amqp.Framing
             }
             else
             {
-                ArrayEncoding.Encode(multiple.ToArray(), buffer);
+                ArrayEncoding.Encode<T>(multiple, buffer);
             }
         }
 

--- a/src/Framing/Multiple.cs
+++ b/src/Framing/Multiple.cs
@@ -38,14 +38,13 @@ namespace Microsoft.Azure.Amqp.Framing
             {
                 return FixedWidth.NullEncoded;
             }
-            else if (multiple.Count == 1)
+
+            if (multiple.Count == 1)
             {
                 return AmqpEncoding.GetObjectEncodeSize(multiple[0]);
             }
-            else
-            {
-                return ArrayEncoding.GetEncodeSize<T>(multiple);
-            }
+
+            return ArrayEncoding.GetEncodeSize(multiple);
         }
 
         internal static void Encode(Multiple<T> multiple, ByteBuffer buffer)
@@ -60,31 +59,23 @@ namespace Microsoft.Azure.Amqp.Framing
             }
             else
             {
-                ArrayEncoding.Encode<T>(multiple, buffer);
+                ArrayEncoding.Encode(multiple, buffer);
             }
         }
 
         internal static Multiple<T> Decode(ByteBuffer buffer)
         {
             object value = AmqpEncoding.DecodeObject(buffer);
-            if (value == null)
+            switch (value)
             {
-                return null;
-            }
-            else if (value is T)
-            {
-                Multiple<T> multiple = new Multiple<T>();
-                multiple.Add((T)value);
-                return multiple;
-            }
-            else if (value.GetType().IsArray)
-            {
-                Multiple<T> multiple = new Multiple<T>((T[])value);
-                return multiple;
-            }
-            else
-            {
-                throw new AmqpException(AmqpErrorCode.InvalidField, null);
+                case null:
+                    return null;
+                case T value1:
+                    return new Multiple<T> { value1 };
+                case T[] valueArray:
+                    return new Multiple<T>(valueArray);
+                default:
+                    throw new AmqpException(AmqpErrorCode.InvalidField, null);
             }
         }
 
@@ -102,8 +93,9 @@ namespace Microsoft.Azure.Amqp.Framing
                 return list;
             }
 
-            foreach (T t1 in multiple1)
+            for (var index = 0; index < multiple1.Count; index++)
             {
+                T t1 = multiple1[index];
                 if (multiple2.Contains(t1))
                 {
                     list.Add(t1);
@@ -121,14 +113,14 @@ namespace Microsoft.Azure.Amqp.Framing
         {
             StringBuilder sb = new StringBuilder("[");
             bool firstItem = true;
-            foreach (object item in this)
+            foreach (var item in this)
             {
                 if (!firstItem)
                 {
                     sb.Append(',');
                 }
 
-                sb.Append(item.ToString());
+                sb.Append(item);
                 firstItem = false;
             }
 

--- a/src/Microsoft.Azure.Amqp.csproj
+++ b/src/Microsoft.Azure.Amqp.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
 </Project>

--- a/test/TestCases/AmqpCodecTests.cs
+++ b/test/TestCases/AmqpCodecTests.cs
@@ -757,7 +757,7 @@
             // Create an object to be serialized
             Person p = new Student("Tom")
                 {
-                    Address = new Address() { FullAddress = new string('B', 1024) }, 
+                    Address = new Address() { FullAddress = new string('B', 1024) },
                     Grades = new List<int>() { 1, 2, 3, 4, 5 }
                 };
             p.Age = 20;
@@ -769,7 +769,7 @@
             var stream = new MemoryStream(new byte[4096], 0, 4096, true, true);
             AmqpContractSerializer.WriteObject(stream, p);
             stream.Flush();
-            
+
             // Deserialize and verify
             stream.Seek(0, SeekOrigin.Begin);
             Person p3 = AmqpContractSerializer.ReadObject<Person>(stream);


### PR DESCRIPTION
This is a work in progress to show how array encoding/decoding of
primitive types can be improved.

## Before

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.985 (20H2/October2020Update)
AMD Ryzen 9 3950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100-preview.4.21255.9
  [Host]   : .NET 5.0.5 (5.0.521.16609), X64 RyuJIT
  ShortRun : .NET 5.0.5 (5.0.521.16609), X64 RyuJIT

Job=ShortRun  Runtime=.NET 5.0  IterationCount=3  
LaunchCount=1  WarmupCount=3  

```
|                         Method |          Mean |         Error |       StdDev |      Gen 0 |   Gen 1 |  Gen 2 |     Allocated | Code Size |
|------------------------------- |--------------:|--------------:|-------------:|-----------:|--------:|-------:|--------------:|----------:|
|   ArrayAmqpSymbolDecode_1M_MAA |     535.44 μs |    149.503 μs |     8.195 μs |    76.1719 | 26.3672 |      - |     647,048 B |     276 B |
|   ArrayAmqpSymbolDecode_1K_MAA |      52.14 μs |      8.871 μs |     0.486 μs |     7.6904 |  0.9155 |      - |      64,480 B |     276 B |
| ArrayAmqpSymbolEncode_100K_MAA |   1,496.76 μs |    192.350 μs |    10.543 μs |    97.6563 |       - |      - |     819,048 B |     226 B |
|   ArrayAmqpSymbolEncode_1K_MAA |     146.51 μs |     40.250 μs |     2.206 μs |     9.7656 |       - |      - |      81,928 B |     226 B |
|               Bytes_Encode_MAA |      23.43 μs |      0.445 μs |     0.024 μs |          - |       - |      - |             - |     326 B |
|               Bytes_Decode_MAA |     320.12 μs |    605.266 μs |    33.177 μs |     2.9297 |  2.9297 | 2.9297 |   1,048,600 B |     555 B |
|        ArrayInt32Encode_MAA_1M | 101,466.66 μs | 28,031.501 μs | 1,536.501 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|        ArrayInt32Encode_MAA_1K |      98.50 μs |     16.658 μs |     0.913 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|        ArrayInt32Decode_1M_MAA |  51,164.37 μs |  4,089.352 μs |   224.151 μs |  3000.0000 |       - |      - |  29,361,027 B |     276 B |
|        ArrayInt32Decode_1K_MAA |      54.88 μs |      3.563 μs |     0.195 μs |     3.4180 |       - |      - |      28,696 B |     276 B |
|       ArrayUInt32Encode_MAA_1M | 105,372.92 μs | 32,508.110 μs | 1,781.879 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|       ArrayUInt32Encode_MAA_1K |      97.29 μs |     19.274 μs |     1.056 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|       ArrayUInt32Decode_1M_MAA |  57,301.39 μs |  3,303.465 μs |   181.074 μs |  3000.0000 |       - |      - |  29,361,148 B |     276 B |
|       ArrayUInt32Decode_1K_MAA |      58.39 μs |      6.783 μs |     0.372 μs |     3.4180 |       - |      - |      28,696 B |     276 B |
|        ArrayInt64Encode_MAA_1M | 105,115.89 μs | 27,232.659 μs | 1,492.714 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|        ArrayInt64Encode_MAA_1K |      98.41 μs |     43.838 μs |     2.403 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|        ArrayInt64Decode_1M_MAA |  51,023.07 μs | 17,808.911 μs |   976.166 μs |  3000.0000 |       - |      - |  33,554,456 B |     276 B |
|        ArrayInt64Decode_1K_MAA |      47.36 μs |      3.820 μs |     0.209 μs |     3.9063 |  0.0610 |      - |      32,792 B |     276 B |
|       ArrayUInt64Encode_MAA_1M | 102,957.17 μs | 18,212.982 μs |   998.315 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|       ArrayUInt64Encode_MAA_1K |      96.94 μs |     59.427 μs |     3.257 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|       ArrayUInt64Decode_1M_MAA |  54,329.93 μs | 30,664.377 μs | 1,680.818 μs |  3000.0000 |       - |      - |  33,554,456 B |     276 B |
|       ArrayUInt64Decode_1K_MAA |      50.64 μs |     24.464 μs |     1.341 μs |     3.9063 |  0.0610 |      - |      32,792 B |     276 B |
|         ArrayBoolEncode_MAA_1M | 104,928.10 μs | 29,551.077 μs | 1,619.794 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|         ArrayBoolEncode_MAA_1K |      96.20 μs |     16.166 μs |     0.886 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|         ArrayBoolDecode_1M_MAA |  44,793.29 μs |  2,699.893 μs |   147.990 μs |  3000.0000 |       - |      - |  26,214,424 B |     276 B |
|         ArrayBoolDecode_1K_MAA |      44.57 μs |      4.078 μs |     0.224 μs |     3.0518 |       - |      - |      25,624 B |     276 B |
|      ArrayDecimalEncode_MAA_1M | 132,444.94 μs | 73,831.727 μs | 4,046.966 μs | 18000.0000 |       - |      - | 150,995,072 B |     320 B |
|      ArrayDecimalEncode_MAA_1K |     129.31 μs |     70.490 μs |     3.864 μs |    17.5781 |       - |      - |     147,584 B |     320 B |
|      ArrayDecimalDecode_1M_MAA | 112,627.93 μs | 13,433.443 μs |   736.332 μs |  9000.0000 |       - |      - |  92,274,712 B |     276 B |
|      ArrayDecimalDecode_1K_MAA |     108.87 μs |     10.047 μs |     0.551 μs |    10.7422 |  0.6104 |      - |      90,136 B |     276 B |
|       ArrayDoubleEncode_MAA_1M | 101,110.83 μs | 22,499.287 μs | 1,233.262 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|       ArrayDoubleEncode_MAA_1K |      98.77 μs |     36.658 μs |     2.009 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|       ArrayDoubleDecode_1M_MAA |  50,673.58 μs | 18,513.259 μs | 1,014.774 μs |  3000.0000 |       - |      - |  33,554,456 B |     276 B |
|       ArrayDoubleDecode_1K_MAA |      45.88 μs |      2.758 μs |     0.151 μs |     3.9063 |  0.0610 |      - |      32,792 B |     276 B |
|        ArrayFloatEncode_MAA_1M | 100,870.10 μs | 14,169.486 μs |   776.677 μs |  6000.0000 |       - |      - |  50,331,760 B |     320 B |
|        ArrayFloatEncode_MAA_1K |     100.00 μs |     20.726 μs |     1.136 μs |     5.8594 |       - |      - |      49,264 B |     320 B |
|        ArrayFloatDecode_1M_MAA |  50,928.70 μs | 10,357.976 μs |   567.756 μs |  3000.0000 |       - |      - |  29,360,227 B |     276 B |
|        ArrayFloatDecode_1K_MAA |      49.35 μs |      3.641 μs |     0.200 μs |     3.4180 |       - |      - |      28,696 B |     276 B |


## After

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.985 (20H2/October2020Update)
AMD Ryzen 9 3950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.100-preview.4.21255.9
  [Host]   : .NET 5.0.5 (5.0.521.16609), X64 RyuJIT
  ShortRun : .NET 5.0.5 (5.0.521.16609), X64 RyuJIT

Job=ShortRun  Runtime=.NET 5.0  IterationCount=3  
LaunchCount=1  WarmupCount=3  

```
|                         Method |            Mean |            Error |        StdDev |     Gen 0 |   Gen 1 |   Gen 2 |    Allocated | Code Size |
|------------------------------- |----------------:|-----------------:|--------------:|----------:|--------:|--------:|-------------:|----------:|
|   ArrayAmqpSymbolDecode_1M_MAA |    337,431.5 ns |     70,315.51 ns |   3,854.23 ns |   47.3633 | 15.6250 |       - |    401,288 B |     276 B |
|   ArrayAmqpSymbolDecode_1K_MAA |     31,422.2 ns |      2,298.39 ns |     125.98 ns |    4.7607 |  0.4883 |       - |     39,904 B |     276 B |
| ArrayAmqpSymbolEncode_100K_MAA |    600,549.1 ns |     22,404.81 ns |   1,228.08 ns |         - |       - |       - |            - |     233 B |
|   ArrayAmqpSymbolEncode_1K_MAA |     58,396.3 ns |      2,661.36 ns |     145.88 ns |         - |       - |       - |            - |     233 B |
|               Bytes_Encode_MAA |     22,882.8 ns |      2,215.89 ns |     121.46 ns |         - |       - |       - |            - |     411 B |
|               Bytes_Decode_MAA |    342,778.9 ns |    890,252.17 ns |  48,797.73 ns |    2.9297 |  2.9297 |  2.9297 |  1,048,601 B |     555 B |
|        ArrayInt32Encode_MAA_1M |    851,541.3 ns |     39,990.25 ns |   2,192.00 ns |         - |       - |       - |            - |     327 B |
|        ArrayInt32Encode_MAA_1K |        950.1 ns |         51.39 ns |       2.82 ns |         - |       - |       - |            - |     327 B |
|        ArrayInt32Decode_1M_MAA |  2,019,578.2 ns |    745,896.04 ns |  40,885.08 ns |   11.7188 | 11.7188 | 11.7188 |  4,194,332 B |     276 B |
|        ArrayInt32Decode_1K_MAA |        972.9 ns |        106.33 ns |       5.83 ns |    0.4921 |       - |       - |      4,120 B |     276 B |
|       ArrayUInt32Encode_MAA_1M |    848,060.4 ns |     12,011.16 ns |     658.37 ns |         - |       - |       - |            - |     327 B |
|       ArrayUInt32Encode_MAA_1K |        940.0 ns |        115.65 ns |       6.34 ns |         - |       - |       - |            - |     327 B |
|       ArrayUInt32Decode_1M_MAA |  2,040,378.3 ns |    564,903.81 ns |  30,964.28 ns |   11.7188 | 11.7188 | 11.7188 |  4,194,332 B |     276 B |
|       ArrayUInt32Decode_1K_MAA |      1,010.7 ns |         94.37 ns |       5.17 ns |    0.4921 |       - |       - |      4,120 B |     276 B |
|        ArrayInt64Encode_MAA_1M |    907,390.7 ns |     89,501.36 ns |   4,905.87 ns |         - |       - |       - |            - |     327 B |
|        ArrayInt64Encode_MAA_1K |        952.1 ns |        115.76 ns |       6.35 ns |         - |       - |       - |            - |     327 B |
|        ArrayInt64Decode_1M_MAA |  3,383,721.9 ns |  3,818,522.36 ns | 209,306.10 ns |   23.4375 | 23.4375 | 23.4375 |  8,388,640 B |     276 B |
|        ArrayInt64Decode_1K_MAA |      1,115.4 ns |         77.21 ns |       4.23 ns |    0.9804 |       - |       - |      8,216 B |     276 B |
|       ArrayUInt64Encode_MAA_1M |    929,740.7 ns |    614,016.69 ns |  33,656.33 ns |         - |       - |       - |            - |     327 B |
|       ArrayUInt64Encode_MAA_1K |        946.0 ns |         35.88 ns |       1.97 ns |         - |       - |       - |            - |     327 B |
|       ArrayUInt64Decode_1M_MAA |  3,450,412.7 ns |  1,869,324.49 ns | 102,463.98 ns |   23.4375 | 23.4375 | 23.4375 |  8,388,640 B |     276 B |
|       ArrayUInt64Decode_1K_MAA |      1,106.5 ns |         90.17 ns |       4.94 ns |    0.9804 |       - |       - |      8,216 B |     276 B |
|         ArrayBoolEncode_MAA_1M |  1,012,373.1 ns |     53,120.62 ns |   2,911.72 ns |         - |       - |       - |          1 B |     327 B |
|         ArrayBoolEncode_MAA_1K |      1,063.6 ns |         44.50 ns |       2.44 ns |         - |       - |       - |            - |     327 B |
|         ArrayBoolDecode_1M_MAA |  1,198,136.6 ns |    191,227.15 ns |  10,481.81 ns |         - |       - |       - |  1,048,601 B |     276 B |
|         ArrayBoolDecode_1K_MAA |      1,073.1 ns |        145.35 ns |       7.97 ns |    0.1240 |       - |       - |      1,048 B |     276 B |
|      ArrayDecimalEncode_MAA_1M | 22,354,117.7 ns |  7,959,300.14 ns | 436,276.10 ns | 5000.0000 |       - |       - | 41,943,049 B |     327 B |
|      ArrayDecimalEncode_MAA_1K |     20,883.4 ns |      1,987.14 ns |     108.92 ns |    4.8828 |       - |       - |     40,960 B |     327 B |
|      ArrayDecimalDecode_1M_MAA | 57,522,114.8 ns | 12,834,405.35 ns | 703,497.06 ns |         - |       - |       - | 16,777,391 B |     276 B |
|      ArrayDecimalDecode_1K_MAA |     52,401.2 ns |      1,246.96 ns |      68.35 ns |    1.9531 |       - |       - |     16,408 B |     276 B |
|       ArrayDoubleEncode_MAA_1M |  1,053,240.8 ns |    823,822.43 ns |  45,156.49 ns |         - |       - |       - |          1 B |     327 B |
|       ArrayDoubleEncode_MAA_1K |      1,064.5 ns |         39.81 ns |       2.18 ns |         - |       - |       - |            - |     327 B |
|       ArrayDoubleDecode_1M_MAA |  3,339,528.0 ns |  2,736,238.70 ns | 149,982.48 ns |   23.4375 | 23.4375 | 23.4375 |  8,388,640 B |     276 B |
|       ArrayDoubleDecode_1K_MAA |      1,092.7 ns |        250.16 ns |      13.71 ns |    0.9804 |       - |       - |      8,216 B |     276 B |
|        ArrayFloatEncode_MAA_1M |  1,256,692.6 ns |     45,829.78 ns |   2,512.08 ns |         - |       - |       - |          1 B |     327 B |
|        ArrayFloatEncode_MAA_1K |      1,315.5 ns |         44.92 ns |       2.46 ns |         - |       - |       - |            - |     327 B |
|        ArrayFloatDecode_1M_MAA |  2,094,115.0 ns |  3,181,908.62 ns | 174,411.15 ns |    7.8125 |  7.8125 |  7.8125 |  4,194,331 B |     276 B |
|        ArrayFloatDecode_1K_MAA |      1,096.8 ns |        282.48 ns |      15.48 ns |    0.4921 |       - |       - |      4,120 B |     276 B |
