### PR TITLE
Use static lambdas

### DIFF
--- a/src/AmqpConnectionFactory.cs
+++ b/src/AmqpConnectionFactory.cs
@@ -213,8 +213,8 @@ namespace Microsoft.Azure.Amqp
 
                 AmqpConnection connection = new AmqpConnection(transport, settings, connectionSettings);
                 await Task.Factory.FromAsync(
-                    (t, k, c, s) => ((AmqpConnection)s).BeginOpen(t, k, c, s),
-                    r => ((AmqpConnection)r.AsyncState).EndOpen(r),
+                    static (t, k, c, s) => ((AmqpConnection)s).BeginOpen(t, k, c, s),
+                    static r => ((AmqpConnection)r.AsyncState).EndOpen(r),
                     timeoutHelper.RemainingTime(),
                     cancellationToken,
                     connection)

--- a/src/AmqpObject.cs
+++ b/src/AmqpObject.cs
@@ -13,31 +13,31 @@ namespace Microsoft.Azure.Amqp
     //                 .=======.
     //                 | start |
     //                 .=======.
-    //             S:Open  |   R:Open           
-    //           +---------+-----------+          
-    //           |                     |          
+    //             S:Open  |   R:Open
+    //           +---------+-----------+
+    //           |                     |
     //       .==========.     .==============.
     //       | OpenSent |     | OpenReceived |
     //       .==========.     .==============.
-    //           | R:Open              |S:Open    
-    //           +---------+-----------+          
-    //                     |                   
-    //                .========.               
-    //                | Opened |               
-    //                .========.               
-    //             S:Close |  R:Close          
-    //           +---------+-----------+          
-    //           |                     |          
-    //      .===========.    .===============. 
-    //      | CloseSent |    | CloseReceived | 
-    //      .===========.    .===============. 
-    //           | R:Close             |S:Close   
-    //           +---------+-----------+          
-    //                     |                   
-    //                 .=======.               
+    //           | R:Open              |S:Open
+    //           +---------+-----------+
+    //                     |
+    //                .========.
+    //                | Opened |
+    //                .========.
+    //             S:Close |  R:Close
+    //           +---------+-----------+
+    //           |                     |
+    //      .===========.    .===============.
+    //      | CloseSent |    | CloseReceived |
+    //      .===========.    .===============.
+    //           | R:Close             |S:Close
+    //           +---------+-----------+
+    //                     |
+    //                 .=======.
     //                 |  End  |
     //                 .=======.
-    //        
+    //
     //      OpenInternal  = Init1 + S:Open + Init2 if Opened
     //      CloseInternal = Cleanup1 + S:Close + Cleanup2 if End
     //
@@ -201,8 +201,8 @@ namespace Microsoft.Azure.Amqp
         public Task OpenAsync(TimeSpan timeout)
         {
             return Task.Factory.FromAsync(
-                (t, c, s) => ((AmqpObject)s).BeginOpen(t, c, s),
-                (a) => ((AmqpObject)a.AsyncState).EndOpen(a),
+                static (t, c, s) => ((AmqpObject)s).BeginOpen(t, c, s),
+                static (a) => ((AmqpObject)a.AsyncState).EndOpen(a),
                 timeout,
                 this);
         }
@@ -215,8 +215,8 @@ namespace Microsoft.Azure.Amqp
         public Task OpenAsync(CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (t, k, c, s) => ((AmqpObject)s).BeginOpen(t, k, c, s),
-                r => ((AmqpObject)r.AsyncState).EndOpen(r),
+                static (t, k, c, s) => ((AmqpObject)s).BeginOpen(t, k, c, s),
+                static r => ((AmqpObject)r.AsyncState).EndOpen(r),
                 AmqpConstants.DefaultTimeout,
                 cancellationToken,
                 this);
@@ -305,8 +305,8 @@ namespace Microsoft.Azure.Amqp
         public Task CloseAsync(TimeSpan timeout)
         {
             return Task.Factory.FromAsync(
-                (t, c, s) => ((AmqpObject)s).BeginClose(t, c, s),
-                (a) => ((AmqpObject)a.AsyncState).EndClose(a),
+                static (t, c, s) => ((AmqpObject)s).BeginClose(t, c, s),
+                static (a) => ((AmqpObject)a.AsyncState).EndClose(a),
                 timeout,
                 this);
         }
@@ -319,8 +319,8 @@ namespace Microsoft.Azure.Amqp
         public Task CloseAsync(CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (t, k, c, s) => ((AmqpObject)s).BeginClose(t, k, c, s),
-                r => ((AmqpObject)r.AsyncState).EndClose(r),
+                static (t, k, c, s) => ((AmqpObject)s).BeginClose(t, k, c, s),
+                static r => ((AmqpObject)r.AsyncState).EndClose(r),
                 AmqpConstants.DefaultTimeout,
                 cancellationToken,
                 this);

--- a/src/AmqpObject.cs
+++ b/src/AmqpObject.cs
@@ -660,7 +660,7 @@ namespace Microsoft.Azure.Amqp
             var openResult = new OpenAsyncResult(this, timeout, callback, state);
             if (cancellationToken.CanBeCanceled)
             {
-                cancellationToken.Register(o => ((AmqpObject)o).CompleteOpen(false, new TaskCanceledException()), this);
+                cancellationToken.Register(static o => ((AmqpObject)o).CompleteOpen(false, new TaskCanceledException()), this);
             }
 
             return openResult;
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.Amqp
                 var closeResult = new CloseAsyncResult(this, timeout, callback, state);
                 if (cancellationToken.CanBeCanceled)
                 {
-                    cancellationToken.Register(o => ((AmqpObject)o).CompleteClose(false, new TaskCanceledException()), this);
+                    cancellationToken.Register(static o => ((AmqpObject)o).CompleteClose(false, new TaskCanceledException()), this);
                 }
 
                 return closeResult;

--- a/src/Microsoft.Azure.Amqp.csproj
+++ b/src/Microsoft.Azure.Amqp.csproj
@@ -22,7 +22,7 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <Configurations>Debug;Release;Signed</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/ReceivingAmqpLink.cs
+++ b/src/ReceivingAmqpLink.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Azure.Amqp
         public Task<AmqpMessage> ReceiveMessageAsync(TimeSpan timeout)
         {
             return Task.Factory.FromAsync(
-                (t, c, s) => ((ReceivingAmqpLink)s).BeginReceiveMessage(t, c, s),
-                (a) =>
+                static (t, c, s) => ((ReceivingAmqpLink)s).BeginReceiveMessage(t, c, s),
+                static (a) =>
                 {
                     ((ReceivingAmqpLink)a.AsyncState).EndReceiveMessage(a, out AmqpMessage message);
                     return message;
@@ -94,8 +94,8 @@ namespace Microsoft.Azure.Amqp
         public Task<AmqpMessage> ReceiveMessageAsync(CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (k, c, s) => ((ReceivingAmqpLink)s).BeginReceiveMessageBatch(1, TimeSpan.Zero, TimeSpan.MaxValue, k, c, s),
-                r => { ((ReceivingAmqpLink)r.AsyncState).EndReceiveMessageBatch(r, out var messages); return messages.Count > 0 ? messages[0] : null; },
+                static (k, c, s) => ((ReceivingAmqpLink)s).BeginReceiveMessageBatch(1, TimeSpan.Zero, TimeSpan.MaxValue, k, c, s),
+                static r => { ((ReceivingAmqpLink)r.AsyncState).EndReceiveMessageBatch(r, out var messages); return messages.Count > 0 ? messages[0] : null; },
                 cancellationToken,
                 this);
         }
@@ -121,8 +121,8 @@ namespace Microsoft.Azure.Amqp
         public Task<IReadOnlyList<AmqpMessage>> ReceiveMessagesAsync(int messageCount, TimeSpan batchWaitTimeout, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (n, b, k, c, s) => ((ReceivingAmqpLink)s).BeginReceiveMessageBatch(n, b, TimeSpan.MaxValue, k, c, s),
-                r => { ((ReceivingAmqpLink)r.AsyncState).EndReceiveMessageBatch(r, out var messages); return messages; },
+                static (n, b, k, c, s) => ((ReceivingAmqpLink)s).BeginReceiveMessageBatch(n, b, TimeSpan.MaxValue, k, c, s),
+                static r => { ((ReceivingAmqpLink)r.AsyncState).EndReceiveMessageBatch(r, out var messages); return messages; },
                 messageCount,
                 batchWaitTimeout,
                 cancellationToken,
@@ -238,8 +238,8 @@ namespace Microsoft.Azure.Amqp
         public Task<Outcome> DisposeMessageAsync(ArraySegment<byte> deliveryTag, ArraySegment<byte> txnId, Outcome outcome, bool batchable, TimeSpan timeout)
         {
             return Task.Factory.FromAsync(
-                (p, t, c, s) => ((ReceivingAmqpLink)s).BeginDisposeMessage(p.DeliveryTag, p.TxnId, p.Outcome, p.Batchable, t, CancellationToken.None, c, s),
-                r => ((ReceivingAmqpLink)r.AsyncState).EndDisposeMessage(r),
+                static (p, t, c, s) => ((ReceivingAmqpLink)s).BeginDisposeMessage(p.DeliveryTag, p.TxnId, p.Outcome, p.Batchable, t, CancellationToken.None, c, s),
+                static r => ((ReceivingAmqpLink)r.AsyncState).EndDisposeMessage(r),
                 new DisposeParam(deliveryTag, txnId, outcome, batchable),
                 timeout,
                 this);
@@ -269,8 +269,8 @@ namespace Microsoft.Azure.Amqp
         public Task<Outcome> DisposeMessageAsync(ArraySegment<byte> deliveryTag, ArraySegment<byte> txnId, Outcome outcome, bool batchable, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (p, k, c, s) => ((ReceivingAmqpLink)s).BeginDisposeMessage(p.DeliveryTag, p.TxnId, p.Outcome, p.Batchable, TimeSpan.MaxValue, k, c, s),
-                r => ((ReceivingAmqpLink)r.AsyncState).EndDisposeMessage(r),
+                static (p, k, c, s) => ((ReceivingAmqpLink)s).BeginDisposeMessage(p.DeliveryTag, p.TxnId, p.Outcome, p.Batchable, TimeSpan.MaxValue, k, c, s),
+                static r => ((ReceivingAmqpLink)r.AsyncState).EndDisposeMessage(r),
                 new DisposeParam(deliveryTag, txnId, outcome, batchable),
                 cancellationToken,
                 this);
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.Amqp
                 {
                     if (this.IsClosing())
                     {
-                        // The closing sequence has been started, so any 
+                        // The closing sequence has been started, so any
                         // transfer is meaningless, so we can treat them as no-op
                         return;
                     }

--- a/src/ReceivingAmqpLink.cs
+++ b/src/ReceivingAmqpLink.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.Amqp
             this.waiterManager.AddWaiter(waiter);
             if (cancellationToken.CanBeCanceled)
             {
-                cancellationToken.Register(o => ((ReceiveAsyncResult)o).Cancel(), waiter);
+                cancellationToken.Register(static o => ((ReceiveAsyncResult)o).Cancel(), waiter);
             }
 
             this.CheckWaiter();
@@ -577,7 +577,7 @@ namespace Microsoft.Azure.Amqp
             var disposeResult = new DisposeAsyncResult(this, deliveryTag, txnId, outcome, batchable, timeout, callback, state);
             if (cancellationToken.CanBeCanceled)
             {
-                cancellationToken.Register(o => ((DisposeAsyncResult)o).Cancel(), disposeResult);
+                cancellationToken.Register(static o => ((DisposeAsyncResult)o).Cancel(), disposeResult);
             }
 
             return disposeResult;

--- a/src/RequestResponseAmqpLink.cs
+++ b/src/RequestResponseAmqpLink.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.Amqp
             var requestResult = new RequestAsyncResult(this, request, txnId, timeout, callback, state);
             if (cancellationToken.CanBeCanceled)
             {
-                cancellationToken.Register(o => ((RequestAsyncResult)o).Cancel(), requestResult);
+                cancellationToken.Register(static o => ((RequestAsyncResult)o).Cancel(), requestResult);
             }
 
             return requestResult;

--- a/src/RequestResponseAmqpLink.cs
+++ b/src/RequestResponseAmqpLink.cs
@@ -171,8 +171,8 @@ namespace Microsoft.Azure.Amqp
         public Task<AmqpMessage> RequestAsync(AmqpMessage request, TimeSpan timeout)
         {
             return Task.Factory.FromAsync(
-                (r, t, c, s) => ((RequestResponseAmqpLink)s).BeginRequest(r, AmqpConstants.NullBinary, t, CancellationToken.None, c, s),
-                (r) => ((RequestResponseAmqpLink)r.AsyncState).EndRequest(r),
+                static (r, t, c, s) => ((RequestResponseAmqpLink)s).BeginRequest(r, AmqpConstants.NullBinary, t, CancellationToken.None, c, s),
+                static (r) => ((RequestResponseAmqpLink)r.AsyncState).EndRequest(r),
                 request,
                 timeout,
                 this);
@@ -187,8 +187,8 @@ namespace Microsoft.Azure.Amqp
         public Task<AmqpMessage> RequestAsync(AmqpMessage request, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (r, k, c, s) => ((RequestResponseAmqpLink)s).BeginRequest(r, AmqpConstants.NullBinary, TimeSpan.MaxValue, k, c, s),
-                (r) => ((RequestResponseAmqpLink)r.AsyncState).EndRequest(r),
+                static (r, k, c, s) => ((RequestResponseAmqpLink)s).BeginRequest(r, AmqpConstants.NullBinary, TimeSpan.MaxValue, k, c, s),
+                static (r) => ((RequestResponseAmqpLink)r.AsyncState).EndRequest(r),
                 request,
                 cancellationToken,
                 this);

--- a/src/SendingAmqpLink.cs
+++ b/src/SendingAmqpLink.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.Amqp
             var sendResult = new SendAsyncResult(this, message, deliveryTag, txnId, timeout, callback, state);
             if (cancellationToken.CanBeCanceled)
             {
-                cancellationToken.Register(o => ((SendAsyncResult)o).Cancel(), sendResult);
+                cancellationToken.Register(static o => ((SendAsyncResult)o).Cancel(), sendResult);
             }
 
             return sendResult;

--- a/src/SendingAmqpLink.cs
+++ b/src/SendingAmqpLink.cs
@@ -87,8 +87,8 @@ namespace Microsoft.Azure.Amqp
         public Task<Outcome> SendMessageAsync(AmqpMessage message, ArraySegment<byte> deliveryTag, ArraySegment<byte> txnId, TimeSpan timeout)
         {
             return Task.Factory.FromAsync(
-                (p, t, c, s) => ((SendingAmqpLink)s).BeginSendMessage(p.Message, p.DeliveryTag, p.TxnId, t, CancellationToken.None, c, s),
-                r => ((SendingAmqpLink)r.AsyncState).EndSendMessage(r),
+                static (p, t, c, s) => ((SendingAmqpLink)s).BeginSendMessage(p.Message, p.DeliveryTag, p.TxnId, t, CancellationToken.None, c, s),
+                static r => ((SendingAmqpLink)r.AsyncState).EndSendMessage(r),
                 new SendMessageParam(message, deliveryTag, txnId),
                 timeout,
                 this);
@@ -105,8 +105,8 @@ namespace Microsoft.Azure.Amqp
         public Task<Outcome> SendMessageAsync(AmqpMessage message, ArraySegment<byte> deliveryTag, ArraySegment<byte> txnId, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (p, k, c, s) => ((SendingAmqpLink)s).BeginSendMessage(p.Message, p.DeliveryTag, p.TxnId, TimeSpan.MaxValue, k, c, s),
-                r => ((SendingAmqpLink)r.AsyncState).EndSendMessage(r),
+                static (p, k, c, s) => ((SendingAmqpLink)s).BeginSendMessage(p.Message, p.DeliveryTag, p.TxnId, TimeSpan.MaxValue, k, c, s),
+                static r => ((SendingAmqpLink)r.AsyncState).EndSendMessage(r),
                 new SendMessageParam(message, deliveryTag, txnId),
                 cancellationToken,
                 this);
@@ -348,12 +348,12 @@ namespace Microsoft.Azure.Amqp
             Outcome outcome;
 
             public SendAsyncResult(
-                SendingAmqpLink link, 
-                AmqpMessage message, 
-                ArraySegment<byte> deliveryTag, 
+                SendingAmqpLink link,
+                AmqpMessage message,
+                ArraySegment<byte> deliveryTag,
                 ArraySegment<byte> txnId,
-                TimeSpan timeout, 
-                AsyncCallback callback, 
+                TimeSpan timeout,
+                AsyncCallback callback,
                 object state)
                 : base(timeout, callback, state)
             {
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.Amqp
                     // the link was canceled because of some termination exception.
                     // Since the termination exception might not be caused
                     // by this specific async result, we should keep throwing
-                    // OperationCancelledException (which is transient) but 
+                    // OperationCancelledException (which is transient) but
                     // use the TerminalException message to allow user to
                     // debug.
                     completionException = new OperationCanceledException(this.link.TerminalException.Message, this.link.TerminalException);

--- a/src/Transport/AmqpTransportInitiator.cs
+++ b/src/Transport/AmqpTransportInitiator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Amqp.Transport
             var args = new TransportAsyncCallbackArgs
             {
                 UserToken = tcs,
-                CompletedCallback = _args =>
+                CompletedCallback = static _args =>
                 {
                     var _tcs = (TaskCompletionSource<TransportBase>)_args.UserToken;
                     if (_args.Exception != null)
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Amqp.Transport
             if (cancellationToken.CanBeCanceled)
             {
                 cancellationToken.Register(
-                    o =>
+                    static o =>
                     {
                         var _args = (TransportAsyncCallbackArgs)o;
                         _args.Transport?.Abort();
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
             AmqpTrace.Provider.AmqpLogOperationInformational(this, TraceOperation.Execute, "ReadHeader");
             byte[] headerBuffer = new byte[AmqpConstants.ProtocolHeaderSize];
-            args.SetBuffer(headerBuffer, 0, headerBuffer.Length); 
+            args.SetBuffer(headerBuffer, 0, headerBuffer.Length);
             args.CompletedCallback = this.OnReadHeaderComplete;
             this.reader.ReadBuffer(args);
         }

--- a/src/Transport/TransportStream.cs
+++ b/src/Transport/TransportStream.cs
@@ -92,8 +92,8 @@ namespace Microsoft.Azure.Amqp.Transport
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (p, k, c, s) => ((TransportStream)s).BeginWrite(p.Array, p.Offset, p.Count, c, s),
-                (a) => ((TransportStream)a.AsyncState).EndWrite(a),
+                static (p, k, c, s) => ((TransportStream)s).BeginWrite(p.Array, p.Offset, p.Count, c, s),
+                static (a) => ((TransportStream)a.AsyncState).EndWrite(a),
                 new ArraySegment<byte>(buffer, offset, count),
                 cancellationToken,
                 this);
@@ -126,8 +126,8 @@ namespace Microsoft.Azure.Amqp.Transport
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             return Task.Factory.FromAsync(
-                (p, k, c, s) => ((TransportStream)s).BeginRead(p.Array, p.Offset, p.Count, c, s),
-                (a) => ((TransportStream)a.AsyncState).EndRead(a),
+                static (p, k, c, s) => ((TransportStream)s).BeginRead(p.Array, p.Offset, p.Count, c, s),
+                static (a) => ((TransportStream)a.AsyncState).EndRead(a),
                 new ArraySegment<byte>(buffer, offset, count),
                 cancellationToken,
                 this);


### PR DESCRIPTION
This enables CSharp 9 and leverages static lambda support from the compiler to make sure that no accidental closure is reintroduced. Using this feature of CSharp 9 is safe. In fact, Azure SDK also uses CSharp 9 with NetStandard.