### PR TITLE
WebSocketTransport Constructor

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/Transport/WebSocketTransport.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Transport/WebSocketTransport.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Amqp.Transport
             }
         }
 
-        internal WebSocketTransport(WebSocket webSocket, Uri uri)
+        public WebSocketTransport(WebSocket webSocket, Uri uri)
             : base(WebSocketTransportSettings.WebSockets)
         {
             this.webSocket = webSocket;


### PR DESCRIPTION
# Summary

The focus of these changes is to change the access scope of the `WebSocketTransport` constructor from `internal` to `public` to mirror that of the other transport types.