### PR TITLE
Throw TCE when canceled

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
@@ -702,7 +702,7 @@ namespace Microsoft.Azure.Amqp
                     {
                         ReceiveAsyncResult result = (ReceiveAsyncResult)o;
                         RemoveFromWaiterList(result);
-                        result.Signal(false, null);
+                        result.Signal(false, new TaskCanceledException());
                     }, this);
                 }
             }


### PR DESCRIPTION
Do we think we can make this change and treat this as a bug fix?

Otherwise, we would need to either handle this in consuming libraries or add a new API.