### PR TITLE
Avoid race condition when canceling

### DIFF
--- a/test/TestCases/CancellationTokenTests.cs
+++ b/test/TestCases/CancellationTokenTests.cs
@@ -507,17 +507,12 @@ namespace Test.Microsoft.Azure.Amqp
                 {
                     cts.Cancel();
                 }
-
-                var task = link.ReceiveMessageAsync(cts.Token);
-                if (!cancelBefore)
+                else
                 {
-                    await Task.Delay(100);
-                    cts.Cancel();
+                    cts.CancelAfter(100);
                 }
 
-                var completedTask = await Task.WhenAny(task, Task.Delay(5000));
-                Assert.Equal(task, completedTask);
-                Assert.True(task.IsCanceled);
+                await Assert.ThrowsAsync<TaskCanceledException>(async () => await link.ReceiveMessageAsync(cts.Token));
             }
             finally
             {


### PR DESCRIPTION
If the token was canceled before ReceiveAsyncResult was finished being constructed, the waiterlist would not be properly cleaned up.

Moved into the Intialize method that is already used for setting up the timer.

Also updated the receive cancellation tests to assert that a TCE is thrown.