### PR TITLE
fix(Singleton): use TaskCreationOptions.RunContinuationsAsynchronously

### DIFF
--- a/src/Fx/Singleton.cs
+++ b/src/Fx/Singleton.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Amqp
                     this.Invalidate(current);
                 }
 
-                tcs = new TaskCompletionSource<TValue>();
+                tcs = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
                 if (this.TrySet(tcs))
                 {
                     try


### PR DESCRIPTION
Possible fix for #204, where we found that a process can be stuck in the call to `TaskCompletionSource.TrySetResult` called from `Singleton.GetOrCreateAsync`.

A possible explanation is that the `TaskCompletionSource` is created with the default option, in which case `TrySetResult` executes the continuations synchronously, which can be a cause of unexpected behaviours and deadlocks. It is highly recommended to use `TaskCreationOptions.RunContinuationsAsynchronously`.

Reference: https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously