### PR TITLE
chore: enable SourceLink

### DIFF
--- a/src/Microsoft.Azure.Amqp.csproj
+++ b/src/Microsoft.Azure.Amqp.csproj
@@ -50,4 +50,12 @@
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
+  <!--
+    Build time packages
+    All should have PrivateAssets="All" set so they don't become package dependencies
+  -->
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Enable SourceLink, which will allow first-class source debugging experience for projects using `Microsoft.Azure.Amqp`. Microsoft libraries, such as the Azure SDK and .NET itself have enabled Source Link.

This would allow an easier analysis of issues like #204.

The package reference and the associated comment are the same as those in the Azure SDK for .NET: https://github.com/Azure/azure-sdk-for-net/blob/943b05e3a3dfc54aaeee000c77303b5072616ec2/eng/Packages.Data.props#L150