### PR TITLE
Revert new abstract method (breaking change)

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/Cbs/AmqpCbsLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/Cbs/AmqpCbsLink.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Amqp
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp.Framing;
@@ -120,6 +121,12 @@ namespace Microsoft.Azure.Amqp
                     cancellationToken,
                     this);
             }
+
+            // Deprecated, but needs to stay available to avoid
+            // breaking changes. The attribute removes it from
+            // any code completion listings and doc generation.
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            protected override Task<RequestResponseAmqpLink> OnCreateAsync(TimeSpan timeout) => OnCreateAsync(timeout, CancellationToken.None);
 
             protected override void OnSafeClose(RequestResponseAmqpLink value)
             {

--- a/Microsoft.Azure.Amqp/Amqp/FaultTolerantAmqpObject.cs
+++ b/Microsoft.Azure.Amqp/Amqp/FaultTolerantAmqpObject.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Amqp
 {
     using System;
+    using System.ComponentModel;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -53,6 +54,12 @@ namespace Microsoft.Azure.Amqp
             amqpObject.SafeAddClosed(OnObjectClosed);
             return amqpObject;
         }
+
+        // Deprecated, but needs to stay available to avoid
+        // breaking changes. The attribute removes it from
+        // any code completion listings and doc generation.
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected override Task<T> OnCreateAsync(TimeSpan timeout) => OnCreateAsync(timeout, CancellationToken.None);
 
         protected override void OnSafeClose(T value)
         {

--- a/Microsoft.Azure.Amqp/Singleton.cs
+++ b/Microsoft.Azure.Amqp/Singleton.cs
@@ -136,10 +136,20 @@ namespace Microsoft.Azure.Amqp
         // Deprecated, but needs to stay available to avoid
         // breaking changes. The attribute removes it from
         // any code completion listings and doc generation.
+        //
+        // This method used to be abstract, but can no longer be to
+        // to avoid callers bound to the new versions from needing to
+        // implement, despite it being deprecated.
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected virtual Task<TValue> OnCreateAsync(TimeSpan timeout) => OnCreateAsync(timeout, CancellationToken.None);
+        protected virtual Task<TValue> OnCreateAsync(TimeSpan timeout) => throw new NotImplementedException();
 
-        protected abstract Task<TValue> OnCreateAsync(TimeSpan timeout, CancellationToken cancellationToken);
+        // This approach is not ideal, as the cancellation token is silently
+        // ignored if this method is not overridden in derived classes.
+        //
+        // However, it is necessary to avoid breaking changes for callers bound
+        // to earlier versions, as they will not have implemented this new method,
+        // so it cannot be abstract and must delegate to the legacy implementation.
+        protected virtual Task<TValue> OnCreateAsync(TimeSpan timeout, CancellationToken cancellationToken) => OnCreateAsync(timeout);
 
         protected abstract void OnSafeClose(TValue value);
 


### PR DESCRIPTION
# Summary

The focus of these changes is to revert the breaking change in Singleton where a new abstract `OnCreateAsync` overload was added.  Doing so required trade-offs which were not ideal.

To ensure that callers build against older versions of the AMQP library could
continue to function, the new overload `OnCreateAsync(TimeSpan, CancellationToken)` is now forwarding to the legacy overload `OnCreateAsync(TimeSpan)` and will silently ignore the cancellation token.  

Because we cannot be sure which `OnCreateAsync` overload derived classes are calling, both have been marked `virtual` rather than any `abstract`; this required having the legacy overload throw when not implemented, since that is the target of delegation.

The defined derived classes `FaultTolerantAmqpObject` and `AmqpCbsLink` have been adjusted to implement both overrides, with the legacy overload calling into the new overload with `CancellationToken.None` specified.  This is intended to ensure that callers bound to older versions continue to work.