### PR TITLE
Implement link stealing

### DIFF
--- a/src/AmqpLink.cs
+++ b/src/AmqpLink.cs
@@ -944,6 +944,11 @@ namespace Microsoft.Azure.Amqp
             this.inflightDeliveries.DoWork(delivery);
         }
 
+        internal void OnLinkStolen()
+        {
+            this.SafeClose(new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.Name, this.Session.Connection.Settings.ContainerId)));
+        }
+
         void DisposeDeliveryInternal(Delivery delivery, bool settled, DeliveryState state, bool noFlush)
         {
             AmqpTrace.Provider.AmqpDispose(this, delivery.DeliveryId.Value, settled, state);

--- a/src/AmqpLink.cs
+++ b/src/AmqpLink.cs
@@ -203,6 +203,11 @@ namespace Microsoft.Azure.Amqp
         /// </summary>
         public bool Drain => this.drain;
 
+        /// <summary>
+        /// Return the <see cref="AmqpLinkIdentifier"/> for this link.
+        /// </summary>
+        public AmqpLinkIdentifier LinkIdentifier => new AmqpLinkIdentifier(this.Name, this.settings.Role, this.Session.Connection.Settings.ContainerId);
+
         internal override TimeSpan OperationTimeout
         {
             get

--- a/src/AmqpLink.cs
+++ b/src/AmqpLink.cs
@@ -944,9 +944,19 @@ namespace Microsoft.Azure.Amqp
             this.inflightDeliveries.DoWork(delivery);
         }
 
-        internal void OnLinkStolen()
+        internal void OnLinkStolen(bool shouldAbort)
         {
-            this.SafeClose(new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.Name, this.Session.Connection.Settings.ContainerId)));
+            AmqpTrace.Provider.AmqpLogOperationInformational(this, shouldAbort ? TraceOperation.Abort : TraceOperation.Close, "LinkStealing");
+
+            this.TerminalException = new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.Name, this.Session.Connection.Settings.ContainerId));
+            if (shouldAbort)
+            {
+                this.Abort();
+            }
+            else
+            {
+                this.Close();
+            }
         }
 
         void DisposeDeliveryInternal(Delivery delivery, bool settled, DeliveryState state, bool noFlush)

--- a/src/AmqpLinkIdentifier.cs
+++ b/src/AmqpLinkIdentifier.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Amqp
+{
+    using Microsoft.Azure.Amqp.Framing;
+    using System;
+
+    /// <summary>
+    /// An object used to uniquely identify a link endpoint.
+    /// </summary>
+    public class AmqpLinkIdentifier
+    {
+        string linkName;
+        bool? role;
+
+        /// <summary>
+        /// Constructor an object used to uniquely identify a link endpoint by using the link name and the link's role (sender/receiver).
+        /// </summary>
+        public AmqpLinkIdentifier(string linkName, bool? role)
+        {
+            this.linkName = linkName;
+            this.role = role;
+        }
+
+        /// <summary>
+        /// Returns the link name.
+        /// </summary>
+        public string Name { get => this.linkName; }
+
+        /// <summary>
+        /// Returns the link role. True if this is used for a receiver, false if it's a sender.
+        /// </summary>
+        public bool? Role { get => this.role; }
+
+        /// <summary>
+        /// Determines whether two link identifiers are equal based on <see cref="Attach.LinkName"/>
+        /// and <see cref="Attach.Role"/>. Name comparison is case insensitive.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            AmqpLinkIdentifier other = obj as AmqpLinkIdentifier;
+            if (other == null || other.linkName == null)
+            {
+                return false;
+            }
+
+            return this.linkName.Equals(other.linkName, StringComparison.CurrentCultureIgnoreCase) && this.role == other.role;
+        }
+
+        /// <summary>
+        /// Gets a hash code of the object.
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return (this.linkName.GetHashCode() * 397) + this.role.GetHashCode();
+        }
+    }
+}

--- a/src/AmqpLinkIdentifier.cs
+++ b/src/AmqpLinkIdentifier.cs
@@ -11,27 +11,40 @@ namespace Microsoft.Azure.Amqp
     /// </summary>
     public class AmqpLinkIdentifier
     {
-        string linkName;
-        bool? role;
-
         /// <summary>
-        /// Constructor an object used to uniquely identify a link endpoint by using the link name and the link's role (sender/receiver).
+        /// Construct an object used to uniquely identify a link endpoint by using the link name, the link's role (sender/receiver), and the containId.
         /// </summary>
-        public AmqpLinkIdentifier(string linkName, bool? role)
+        public AmqpLinkIdentifier(string linkName, bool? role, string containerId)
         {
-            this.linkName = linkName;
-            this.role = role;
+            if (linkName == null)
+            {
+                throw new ArgumentNullException(nameof(linkName));
+            }
+
+            if (containerId == null)
+            {
+                throw new ArgumentNullException(nameof(containerId));
+            }
+
+            this.LinkName = linkName;
+            this.Role = role;
+            this.ContainerId = containerId;
         }
 
         /// <summary>
         /// Returns the link name.
         /// </summary>
-        public string Name { get => this.linkName; }
+        public string LinkName { get; }
 
         /// <summary>
         /// Returns the link role. True if this is used for a receiver, false if it's a sender.
         /// </summary>
-        public bool? Role { get => this.role; }
+        public bool? Role { get; }
+
+        /// <summary>
+        /// Returns the containerId for the link endpoint.
+        /// </summary>
+        public string ContainerId { get; }
 
         /// <summary>
         /// Determines whether two link identifiers are equal based on <see cref="Attach.LinkName"/>
@@ -42,21 +55,22 @@ namespace Microsoft.Azure.Amqp
         public override bool Equals(object obj)
         {
             AmqpLinkIdentifier other = obj as AmqpLinkIdentifier;
-            if (other == null || other.linkName == null)
+            if (other == null)
             {
                 return false;
             }
 
-            return this.linkName.Equals(other.linkName, StringComparison.CurrentCultureIgnoreCase) && this.role == other.role;
+            return this.LinkName.Equals(other.LinkName, StringComparison.CurrentCultureIgnoreCase)
+                && this.Role == other.Role
+                && this.ContainerId.Equals(other.ContainerId, StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>
         /// Gets a hash code of the object.
         /// </summary>
-        /// <returns></returns>
         public override int GetHashCode()
         {
-            return (this.linkName.GetHashCode() * 397) + this.role.GetHashCode();
+            return (this.LinkName.ToLower().GetHashCode() * 397) + this.Role.GetHashCode() + (this.ContainerId.ToLower().GetHashCode() * 397);
         }
     }
 }

--- a/src/AmqpLinkSettings.cs
+++ b/src/AmqpLinkSettings.cs
@@ -109,11 +109,6 @@ namespace Microsoft.Azure.Amqp
         internal TimeSpan OperationTimeoutInternal => this.operationTimeout;
 
         /// <summary>
-        /// Get the object used to uniquely identify an <see cref="AmqpLink"/>.
-        /// </summary>
-        internal AmqpLinkIdentifier LinkIdentifier => new AmqpLinkIdentifier(this.LinkName, this.Role);
-
-        /// <summary>
         /// Creates a settings object from an attach.
         /// </summary>
         /// <param name="attach">The attach.</param>
@@ -145,22 +140,30 @@ namespace Microsoft.Azure.Amqp
         }
 
         /// <summary>
-        /// Determines whether two link settings are equal based on the <see cref="AmqpLinkIdentifier"/>.
+        /// Determines whether two link settings are equal based on <see cref="Attach.LinkName"/>
+        /// and <see cref="Attach.Role"/>. Name comparison is case insensitive.
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
             AmqpLinkSettings other = obj as AmqpLinkSettings;
-            return this.LinkIdentifier.Equals(other.LinkIdentifier);
+            if (other == null || other.LinkName == null)
+            {
+                return false;
+            }
+
+            return this.LinkName.Equals(other.LinkName, StringComparison.CurrentCultureIgnoreCase) &&
+                this.Role == other.Role;
         }
 
         /// <summary>
-        /// Get the hashcode of the link settings based on the hashcode of its <see cref="AmqpLinkIdentifier"/>.
+        /// Gets a hash code of the object.
         /// </summary>
+        /// <returns></returns>
         public override int GetHashCode()
         {
-            return this.LinkIdentifier.GetHashCode();
+            return (this.LinkName.GetHashCode() * 397) + this.Role.GetHashCode();
         }
     }
 }

--- a/src/AmqpLinkSettings.cs
+++ b/src/AmqpLinkSettings.cs
@@ -109,6 +109,11 @@ namespace Microsoft.Azure.Amqp
         internal TimeSpan OperationTimeoutInternal => this.operationTimeout;
 
         /// <summary>
+        /// Get the object used to uniquely identify an <see cref="AmqpLink"/>.
+        /// </summary>
+        internal AmqpLinkIdentifier LinkIdentifier => new AmqpLinkIdentifier(this.LinkName, this.Role);
+
+        /// <summary>
         /// Creates a settings object from an attach.
         /// </summary>
         /// <param name="attach">The attach.</param>
@@ -140,30 +145,22 @@ namespace Microsoft.Azure.Amqp
         }
 
         /// <summary>
-        /// Determines whether two link settings are equal based on <see cref="Attach.LinkName"/>
-        /// and <see cref="Attach.Role"/>. Name comparison is case insensitive.
+        /// Determines whether two link settings are equal based on the <see cref="AmqpLinkIdentifier"/>.
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
         /// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
             AmqpLinkSettings other = obj as AmqpLinkSettings;
-            if (other == null || other.LinkName == null)
-            {
-                return false;
-            }
-
-            return this.LinkName.Equals(other.LinkName, StringComparison.CurrentCultureIgnoreCase) &&
-                this.Role == other.Role;
+            return this.LinkIdentifier.Equals(other.LinkIdentifier);
         }
 
         /// <summary>
-        /// Gets a hash code of the object.
+        /// Get the hashcode of the link settings based on the hashcode of its <see cref="AmqpLinkIdentifier"/>.
         /// </summary>
-        /// <returns></returns>
         public override int GetHashCode()
         {
-            return (this.LinkName.GetHashCode() * 397) + this.Role.GetHashCode();
+            return this.LinkIdentifier.GetHashCode();
         }
     }
 }

--- a/src/Resources.Designer.cs
+++ b/src/Resources.Designer.cs
@@ -394,6 +394,15 @@ namespace Microsoft.Azure.Amqp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The link with link name {0} under connection with containerId {1} has been closed due to link stealing. .
+        /// </summary>
+        internal static string AmqpLinkStolen {
+            get {
+                return ResourceManager.GetString("AmqpLinkStolen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A link to connection &apos;{0}&apos; $management node has already been opened..
         /// </summary>
         internal static string AmqpManagementLinkAlreadyOpen {

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -291,4 +291,7 @@
   <data name="AmqpTransportUpgradeNotAllowed" xml:space="preserve">
     <value>Cannot upgrade transport from type '{0}' to '{1}'.</value>
   </data>
+  <data name="AmqpLinkStolen" xml:space="preserve">
+    <value>The link with link name {0} under connection with containerId {1} has been closed due to link stealing. </value>
+  </data>
 </root>

--- a/test/TestCases/AmqpLinkTests.cs
+++ b/test/TestCases/AmqpLinkTests.cs
@@ -1132,6 +1132,36 @@ namespace Test.Microsoft.Azure.Amqp
             await connection.CloseAsync(TimeSpan.FromSeconds(20));
         }
 
+        [Fact]
+        public void LinkIdentifierTest()
+        {
+            var original = new AmqpLinkIdentifier("Sender", false, "ContainerID");
+            IDictionary<AmqpLinkIdentifier, object> dictionary = new Dictionary<AmqpLinkIdentifier, object>();
+            dictionary.Add(original, new object());
+
+            // link name is case insensitive
+            Assert.True(dictionary.ContainsKey(new AmqpLinkIdentifier("sender", false, "ContainerID")));
+            Assert.Equal(original, new AmqpLinkIdentifier("sender", false, "ContainerID"));
+
+            // containerId is case insensitive
+            Assert.True(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", false, "containerid")));
+            Assert.Equal(original, new AmqpLinkIdentifier("Sender", false, "containerid"));
+
+            // different linkNames
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender1", false, "ContainerID")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender1", false, "ContainerID"));
+
+            // different roles
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", null, "ContainerID")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", null, "ContainerID"));
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", true, "ContainerID")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", true, "ContainerID"));
+
+            // different containerId
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", false, "ContainerID1")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", false, "ContainerID1"));
+        }
+
         /// <summary>
         /// Test link stealing where two links have the same link name but different link types. They should both be able to open without interfering each other.
         /// </summary>
@@ -1145,7 +1175,7 @@ namespace Test.Microsoft.Azure.Amqp
         /// Test link stealing where two links have the same link name and type, but the link1 is closed before link2 is opened. This should not trigger any link stealing at all.
         /// </summary>
         [Fact]
-        public async Task LinkStealingCloseLink1TypesTest()
+        public async Task LinkStealingCloseLink1FirstTest()
         {
             await LinkStealingTestCase(true, true);
         }


### PR DESCRIPTION
Implement link stealing by introducing a new object to uniquely identify link endpoints based on link name and link role, instead of just link name before.