### PR TITLE
Enable link stealing by introducing new link identifier object to track uniqueness of links

### DIFF
--- a/src/AmqpLink.cs
+++ b/src/AmqpLink.cs
@@ -951,16 +951,19 @@ namespace Microsoft.Azure.Amqp
 
         internal void OnLinkStolen(bool shouldAbort)
         {
-            AmqpTrace.Provider.AmqpLogOperationInformational(this, shouldAbort ? TraceOperation.Abort : TraceOperation.Close, "LinkStealing");
+            if (!this.IsClosing())
+            {
+                AmqpTrace.Provider.AmqpLogOperationInformational(this, shouldAbort ? TraceOperation.Abort : TraceOperation.Close, "LinkStealing");
 
-            this.TerminalException = new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.LinkIdentifier));
-            if (shouldAbort)
-            {
-                this.Abort();
-            }
-            else
-            {
-                this.Close();
+                this.TerminalException = new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.LinkIdentifier));
+                if (shouldAbort)
+                {
+                    this.Abort();
+                }
+                else
+                {
+                    this.Close();
+                }
             }
         }
 

--- a/src/AmqpLink.cs
+++ b/src/AmqpLink.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Amqp
         /// <summary>
         /// Return the <see cref="AmqpLinkIdentifier"/> for this link.
         /// </summary>
-        public AmqpLinkIdentifier LinkIdentifier => new AmqpLinkIdentifier(this.Name, this.settings.Role, this.Session.Connection.Settings.ContainerId);
+        public AmqpLinkIdentifier LinkIdentifier => new AmqpLinkIdentifier(this.Name, this.settings.IsReceiver(), this.Session.Connection.Settings.ContainerId);
 
         internal override TimeSpan OperationTimeout
         {

--- a/src/AmqpLink.cs
+++ b/src/AmqpLink.cs
@@ -953,7 +953,7 @@ namespace Microsoft.Azure.Amqp
         {
             AmqpTrace.Provider.AmqpLogOperationInformational(this, shouldAbort ? TraceOperation.Abort : TraceOperation.Close, "LinkStealing");
 
-            this.TerminalException = new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.Name, this.Session.Connection.Settings.ContainerId));
+            this.TerminalException = new AmqpException(AmqpErrorCode.Stolen, AmqpResources.GetString(AmqpResources.AmqpLinkStolen, this.LinkIdentifier));
             if (shouldAbort)
             {
                 this.Abort();

--- a/src/AmqpLinkIdentifier.cs
+++ b/src/AmqpLinkIdentifier.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Amqp
+{
+    using Microsoft.Azure.Amqp.Framing;
+    using System;
+
+    /// <summary>
+    /// An object used to uniquely identify a link endpoint.
+    /// </summary>
+    public class AmqpLinkIdentifier
+    {
+        /// <summary>
+        /// Construct an object used to uniquely identify a link endpoint by using the link name, the link's role (sender/receiver), and the containId.
+        /// </summary>
+        public AmqpLinkIdentifier(string linkName, bool? role, string containerId)
+        {
+            if (linkName == null)
+            {
+                throw new ArgumentNullException(nameof(linkName));
+            }
+
+            if (containerId == null)
+            {
+                throw new ArgumentNullException(nameof(containerId));
+            }
+
+            this.LinkName = linkName;
+            this.Role = role;
+            this.ContainerId = containerId;
+        }
+
+        /// <summary>
+        /// Returns the link name.
+        /// </summary>
+        public string LinkName { get; }
+
+        /// <summary>
+        /// Returns the link role. True if this is used for a receiver, false if it's a sender.
+        /// </summary>
+        public bool? Role { get; }
+
+        /// <summary>
+        /// Returns the containerId for the link endpoint.
+        /// </summary>
+        public string ContainerId { get; }
+
+        /// <summary>
+        /// Determines whether two link identifiers are equal based on <see cref="Attach.LinkName"/>
+        /// and <see cref="Attach.Role"/>. Name comparison is case insensitive.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            AmqpLinkIdentifier other = obj as AmqpLinkIdentifier;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return this.LinkName.Equals(other.LinkName, StringComparison.CurrentCultureIgnoreCase)
+                && this.Role == other.Role
+                && this.ContainerId.Equals(other.ContainerId, StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets a hash code of the object.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return (this.LinkName.ToLower().GetHashCode() * 397) + this.Role.GetHashCode() + (this.ContainerId.ToLower().GetHashCode() * 397);
+        }
+    }
+}

--- a/src/AmqpLinkIdentifier.cs
+++ b/src/AmqpLinkIdentifier.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Amqp
     public class AmqpLinkIdentifier
     {
         /// <summary>
-        /// Construct an object used to uniquely identify a link endpoint by using the link name, the link's role (sender/receiver), and the containId.
+        /// Construct an object used to uniquely identify a link endpoint by using the link name, the link's role (sender/receiver), and the containerId.
         /// </summary>
         public AmqpLinkIdentifier(string linkName, bool? role, string containerId)
         {
@@ -71,6 +71,14 @@ namespace Microsoft.Azure.Amqp
         public override int GetHashCode()
         {
             return (this.LinkName.ToLower().GetHashCode() * 397) + this.Role.GetHashCode() + (this.ContainerId.ToLower().GetHashCode() * 397);
+        }
+
+        /// <summary>
+        /// Return the string representation of the link identifier.
+        /// </summary>
+        public override string ToString()
+        {
+            return $"{(this.Role == true ? "Receiver" : "Sender")}|LinkName={this.LinkName}|ContainerId={this.ContainerId}";
         }
     }
 }

--- a/src/AmqpLinkIdentifier.cs
+++ b/src/AmqpLinkIdentifier.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Azure.Amqp
     public class AmqpLinkIdentifier
     {
         /// <summary>
-        /// Construct an object used to uniquely identify a link endpoint by using the link name, the link's role (sender/receiver), and the containerId.
+        /// Construct an object used to uniquely identify a link endpoint by using the link name, the link's role (receiver/sender), and the containerId.
         /// </summary>
-        public AmqpLinkIdentifier(string linkName, bool? role, string containerId)
+        public AmqpLinkIdentifier(string linkName, bool isReceiver, string containerId)
         {
             if (linkName == null)
             {
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Amqp
             }
 
             this.LinkName = linkName;
-            this.Role = role;
+            this.IsReceiver = isReceiver;
             this.ContainerId = containerId;
         }
 
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Amqp
         /// <summary>
         /// Returns the link role. True if this is used for a receiver, false if it's a sender.
         /// </summary>
-        public bool? Role { get; }
+        public bool IsReceiver { get; }
 
         /// <summary>
         /// Returns the containerId for the link endpoint.
@@ -60,9 +60,9 @@ namespace Microsoft.Azure.Amqp
                 return false;
             }
 
-            return this.LinkName.Equals(other.LinkName, StringComparison.CurrentCultureIgnoreCase)
-                && this.Role == other.Role
-                && this.ContainerId.Equals(other.ContainerId, StringComparison.CurrentCultureIgnoreCase);
+            return this.LinkName.Equals(other.LinkName, StringComparison.OrdinalIgnoreCase)
+                && this.IsReceiver == other.IsReceiver
+                && this.ContainerId.Equals(other.ContainerId, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -70,7 +70,11 @@ namespace Microsoft.Azure.Amqp
         /// </summary>
         public override int GetHashCode()
         {
-            return (this.LinkName.ToLower().GetHashCode() * 397) + this.Role.GetHashCode() + (this.ContainerId.ToLower().GetHashCode() * 397);
+            int hash = 29;
+            hash = hash * 397 + StringComparer.OrdinalIgnoreCase.GetHashCode(this.LinkName);
+            hash = hash * 397 + this.IsReceiver.GetHashCode();
+            hash = hash * 397 + StringComparer.OrdinalIgnoreCase.GetHashCode(this.ContainerId);
+            return hash;
         }
 
         /// <summary>
@@ -78,7 +82,7 @@ namespace Microsoft.Azure.Amqp
         /// </summary>
         public override string ToString()
         {
-            return $"{(this.Role == true ? "Receiver" : "Sender")}|LinkName={this.LinkName}|ContainerId={this.ContainerId}";
+            return $"{(this.IsReceiver ? "Receiver" : "Sender")}|LinkName={this.LinkName}|ContainerId={this.ContainerId}";
         }
     }
 }

--- a/src/AmqpSession.cs
+++ b/src/AmqpSession.cs
@@ -577,7 +577,7 @@ namespace Microsoft.Azure.Amqp
             if (command.DescriptorCode == Attach.Code)
             {
                 Attach attach = (Attach)command;
-                var linkIdentifier = new AmqpLinkIdentifier(attach.LinkName, !attach.Role, this.Connection.Settings.ContainerId); // local Role will be opposite of the Role sent from remote for the same link.
+                var linkIdentifier = new AmqpLinkIdentifier(attach.LinkName, !attach.IsReceiver(), this.Connection.Settings.ContainerId); // local Role will be opposite of the Role sent from remote for the same link.
 
                 lock (this.ThisLock)
                 {

--- a/src/AmqpSession.cs
+++ b/src/AmqpSession.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Amqp
         readonly AmqpConnection connection;
         readonly AmqpSessionSettings settings;
         readonly ILinkFactory linkFactory;
-        Dictionary<string, AmqpLink> links;
+        Dictionary<AmqpLinkIdentifier, AmqpLink> links;
         HandleTable<AmqpLink> linksByLocalHandle;
         HandleTable<AmqpLink> linksByRemoteHandle;
         OutgoingSessionChannel outgoingChannel;
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Amqp
             this.settings = settings;
             this.linkFactory = linkFactory;
             this.State = AmqpObjectState.Start;
-            this.links = new Dictionary<string, AmqpLink>();
+            this.links = new Dictionary<AmqpLinkIdentifier, AmqpLink>();
             this.linksByLocalHandle = new HandleTable<AmqpLink>(settings.HandleMax ?? AmqpConstants.DefaultMaxLinkHandles - 1);
             this.linksByRemoteHandle = new HandleTable<AmqpLink>(settings.HandleMax ?? AmqpConstants.DefaultMaxLinkHandles - 1);
             this.outgoingChannel = new OutgoingSessionChannel(this);
@@ -167,6 +167,7 @@ namespace Microsoft.Azure.Amqp
         public void AttachLink(AmqpLink link)
         {
             Fx.Assert(link.Session == this, "The link is not owned by this session.");
+            AmqpLink existingLink;
 
             lock (this.ThisLock)
             {
@@ -175,14 +176,22 @@ namespace Microsoft.Azure.Amqp
                     throw new InvalidOperationException(AmqpResources.GetString(AmqpResources.AmqpIllegalOperationState, "attach", this.State));
                 }
 
-                if (this.links.ContainsKey(link.Name))
+                if (this.links.TryGetValue(link.LinkIdentifier, out existingLink))
                 {
-                    throw new AmqpException(AmqpErrorCode.ResourceLocked, AmqpResources.GetString(AmqpResources.AmqpLinkNameInUse, link.Name, this.LocalChannel));
+                    // even though link onclose handler already removes the link from the links collection,
+                    // calling Close() is fire and forget, so we will not be waiting for the link onClose handler to trigger
+                    // before trying to add the new link to the links collection down below in this method, therefore remove it now.
+                    this.links.Remove(link.LinkIdentifier);
                 }
 
                 link.Closed += onLinkClosed;
-                this.links.Add(link.Name, link);
+                this.links.Add(link.LinkIdentifier, link);
                 link.LocalHandle = this.linksByLocalHandle.Add(link);
+            }
+
+            if (existingLink != null)
+            {
+                existingLink.OnLinkStolen(false);
             }
 
             AmqpTrace.Provider.AmqpAttachLink(this.connection, this, link, link.LocalHandle.Value,
@@ -397,16 +406,15 @@ namespace Microsoft.Azure.Amqp
             return transition.To;
         }
 
-        internal bool TryCreateRemoteLink(Attach attach, out AmqpLink link)
+        internal bool TryCreateRemoteLink(AmqpLinkSettings linkSettings, out AmqpLink link)
         {
             link = null;
+            Exception error = null;
+
             if (this.linkFactory == null)
             {
                 return false;
             }
-
-            AmqpLinkSettings linkSettings = AmqpLinkSettings.Create(attach);
-            Exception error = null;
 
             try
             {
@@ -431,8 +439,8 @@ namespace Microsoft.Azure.Amqp
                 error = exception;
             }
 
-            link.RemoteHandle = attach.Handle;
-            this.linksByRemoteHandle.Add(attach.Handle.Value, link);
+            link.RemoteHandle = linkSettings.Handle;
+            this.linksByRemoteHandle.Add(linkSettings.Handle.Value, link);
 
             if (error != null)
             {
@@ -563,24 +571,46 @@ namespace Microsoft.Azure.Amqp
         void OnReceiveLinkFrame(Frame frame)
         {
             AmqpLink link = null;
+            AmqpLink stolenLink = null;
             Performative command = frame.Command;
             if (command.DescriptorCode == Attach.Code)
             {
                 Attach attach = (Attach)command;
+                AmqpLinkSettings linkSettings = AmqpLinkSettings.Create(attach);
+                var linkIdentifier = new AmqpLinkIdentifier(linkSettings.LinkName, linkSettings.Role, this.Connection.Settings.ContainerId);
+
                 lock (this.ThisLock)
                 {
-                    this.links.TryGetValue(attach.LinkName, out link);
+                    this.links.TryGetValue(linkIdentifier, out link);
+                    if (link != null && link.State >= AmqpObjectState.OpenReceived)
+                    {
+                        // If the link state is past OpenReceived, it means that the link has already received an Attach frame from remote, regardless if the link open was initiated by local or remote.
+                        // A single link life cycle should not receive Attach more than once, therefore if the existing link has already received an Attach, this current Attach must be intended for another link.
+                        // In that case, remove the existing link due to link stealing and create a new link based on the Attach frame received.
+                        stolenLink = link;
+                        this.links.Remove(linkIdentifier);
+                    }
+                }
+
+                if (stolenLink != null)
+                {
+                    // Abort the local existing link, which does not send a detach back to remote, who initiated opening a new link and is not expecting the new link to be closed.
+                    stolenLink.OnLinkStolen(true);
+                    link = null;
                 }
 
                 if (link == null)
                 {
-                    if (!this.TryCreateRemoteLink(attach, out link))
+                    if (!this.TryCreateRemoteLink(linkSettings, out link))
                     {
                         return;
                     }
                 }
                 else
                 {
+                    // This scenario indicates that the existing link has already been created locally but no Attach has been received yet.
+                    // This could only mean that the link open was initiated from local, so this Attach frame received is the reply from remote in response to the initial Attach sent by local.
+                    // Therefore, we do not need to open or close anything from local side because we just need to complete the open process locally.
                     lock (this.ThisLock)
                     {
                         link.RemoteHandle = attach.Handle;
@@ -650,7 +680,11 @@ namespace Microsoft.Azure.Amqp
             lock (thisPtr.ThisLock)
             {
                 link.Closed -= onLinkClosed;
-                thisPtr.links.Remove(link.Name);
+                if (thisPtr.links.TryGetValue(link.LinkIdentifier, out AmqpLink existingLink) && link == existingLink)
+                {
+                    thisPtr.links.Remove(link.LinkIdentifier);
+                }
+
                 if (link.LocalHandle.HasValue)
                 {
                     thisPtr.linksByLocalHandle.Remove(link.LocalHandle.Value);

--- a/src/Resources.Designer.cs
+++ b/src/Resources.Designer.cs
@@ -394,6 +394,15 @@ namespace Microsoft.Azure.Amqp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The link with link name {0} under connection with containerId {1} has been closed due to link stealing. .
+        /// </summary>
+        internal static string AmqpLinkStolen {
+            get {
+                return ResourceManager.GetString("AmqpLinkStolen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A link to connection &apos;{0}&apos; $management node has already been opened..
         /// </summary>
         internal static string AmqpManagementLinkAlreadyOpen {

--- a/src/Resources.Designer.cs
+++ b/src/Resources.Designer.cs
@@ -383,16 +383,7 @@ namespace Microsoft.Azure.Amqp {
                 return ResourceManager.GetString("AmqpInvalidType", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A link with name &apos;{0}&apos; is already attached in session {1}..
-        /// </summary>
-        internal static string AmqpLinkNameInUse {
-            get {
-                return ResourceManager.GetString("AmqpLinkNameInUse", resourceCulture);
-            }
-        }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The link with link name {0} under connection with containerId {1} has been closed due to link stealing. .
         /// </summary>

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -291,4 +291,7 @@
   <data name="AmqpTransportUpgradeNotAllowed" xml:space="preserve">
     <value>Cannot upgrade transport from type '{0}' to '{1}'.</value>
   </data>
+  <data name="AmqpLinkStolen" xml:space="preserve">
+    <value>The link with link name {0} under connection with containerId {1} has been closed due to link stealing. </value>
+  </data>
 </root>

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -279,9 +279,6 @@
   <data name="AmqpTransportNotSecure" xml:space="preserve">
     <value>The current transport is not secure. Establish a secure transport by setting AmqpTransportSettings.UseSslStreamSecurity to true.</value>
   </data>
-  <data name="AmqpLinkNameInUse" xml:space="preserve">
-    <value>A link with name '{0}' is already attached in session {1}.</value>
-  </data>
   <data name="AmqpEmptyMessageNotAllowed" xml:space="preserve">
     <value>Sending an emtpy message is not allowed. At least one message section must be initialized.</value>
   </data>
@@ -292,6 +289,6 @@
     <value>Cannot upgrade transport from type '{0}' to '{1}'.</value>
   </data>
   <data name="AmqpLinkStolen" xml:space="preserve">
-    <value>The link with link name {0} under connection with containerId {1} has been closed due to link stealing. </value>
+    <value>The link with identifier {0} has been closed due to link stealing. </value>
   </data>
 </root>

--- a/test/Test.Microsoft.Amqp/TestCases/AmqpLinkIdentifierTest.cs
+++ b/test/Test.Microsoft.Amqp/TestCases/AmqpLinkIdentifierTest.cs
@@ -30,8 +30,6 @@ namespace Test.Microsoft.Azure.Amqp
             Assert.NotEqual(original, new AmqpLinkIdentifier("Sender1", false, "ContainerID"));
 
             // different roles
-            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", null, "ContainerID")));
-            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", null, "ContainerID"));
             Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", true, "ContainerID")));
             Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", true, "ContainerID"));
 

--- a/test/Test.Microsoft.Amqp/TestCases/AmqpLinkIdentifierTest.cs
+++ b/test/Test.Microsoft.Amqp/TestCases/AmqpLinkIdentifierTest.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test.Microsoft.Azure.Amqp
+{
+    using System.Collections.Generic;
+    using global::Microsoft.Azure.Amqp;
+    using Xunit;
+
+    [Trait("Category", TestCategory.Current)]
+    public class AmqpLinkIdentifierTest
+    {
+        [Fact]
+        public void LinkIdentifierTest()
+        {
+            var original = new AmqpLinkIdentifier("Sender", false, "ContainerID");
+            IDictionary<AmqpLinkIdentifier, object> dictionary = new Dictionary<AmqpLinkIdentifier, object>();
+            dictionary.Add(original, new object());
+
+            // link name is case insensitive
+            Assert.True(dictionary.ContainsKey(new AmqpLinkIdentifier("sender", false, "ContainerID")));
+            Assert.Equal(original, new AmqpLinkIdentifier("sender", false, "ContainerID"));
+
+            // containerId is case insensitive
+            Assert.True(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", false, "containerid")));
+            Assert.Equal(original, new AmqpLinkIdentifier("Sender", false, "containerid"));
+
+            // different linkNames
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender1", false, "ContainerID")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender1", false, "ContainerID"));
+
+            // different roles
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", null, "ContainerID")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", null, "ContainerID"));
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", true, "ContainerID")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", true, "ContainerID"));
+
+            // different containerId
+            Assert.False(dictionary.ContainsKey(new AmqpLinkIdentifier("Sender", false, "ContainerID1")));
+            Assert.NotEqual(original, new AmqpLinkIdentifier("Sender", false, "ContainerID1"));
+        }
+    }
+}


### PR DESCRIPTION
- Introduced a new class, AmqpLinkIdentifier, to track the uniqueness of link endpoints, which consists of the link name, role, nd containerId.
- Track link instances within an AmqpSession by using this link identifier object instead of just the name.
- When attempting to create a new link, close any existing one with identical link identifier due to link stealing, instead of the current behavior of blocking the opening of the new link due to resource locking.