### PR TITLE
Allow users to provide a ClientWebSocket instance for web socket communication

### DIFF
--- a/src/Transport/WebSocketTransportInitiator.cs
+++ b/src/Transport/WebSocketTransportInitiator.cs
@@ -20,7 +20,16 @@ namespace Microsoft.Azure.Amqp.Transport
 
         public override bool ConnectAsync(TimeSpan timeout, TransportAsyncCallbackArgs callbackArgs)
         {
-            ClientWebSocket cws = new ClientWebSocket();
+            ClientWebSocket cws;
+            if (this.settings.WebSocket != null)
+            {
+                cws = this.settings.WebSocket;
+            }
+            else
+            { 
+                cws = new ClientWebSocket();
+            }
+
             cws.Options.AddSubProtocol(this.settings.SubProtocol);
             if (this.settings.InternalSendBufferSize > 0 || this.settings.InternalReceiveBufferSize > 0)
             {

--- a/src/Transport/WebSocketTransportSettings.cs
+++ b/src/Transport/WebSocketTransportSettings.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Amqp.Transport
 {
     using System;
     using System.Net;
+    using System.Net.WebSockets;
 
     /// <summary>
     /// Defines the web socket transport settings.
@@ -57,6 +58,15 @@ namespace Microsoft.Azure.Amqp.Transport
         /// Gets or sets the websocket keep alive interval.
         /// </summary>
         public TimeSpan? WebsocketKeepAliveInterval
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The ClientWebSocket instance to communicate over.
+        /// </summary>
+        public ClientWebSocket WebSocket
         {
             get;
             set;


### PR DESCRIPTION
This will allow users to access features only present in newer .NET versions like RemoteCertificateValidationCallback without targeting those frameworks in this project