### PR TITLE
Add trimming/AOT annotations

### DIFF
--- a/src/AmqpEventSource.cs
+++ b/src/AmqpEventSource.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Amqp
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
 
     [EventSource(Name = "Microsoft-Azure-Amqp")]
@@ -15,6 +16,8 @@ namespace Microsoft.Azure.Amqp
         // 3. When changing the event definition, update callers in AmqpTrace
         //    if needed.
 
+        private const string EventSourceSuppressMessage = "Parameters to this method are primitive and are trimmer safe.";
+
         public static readonly AmqpEventSource Log;
 
         static AmqpEventSource()
@@ -23,6 +26,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [Event(1, Level = EventLevel.Informational, Message = "{0}: open connection {1}.")]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         public unsafe void AmqpOpenConnection(string source, string connection)
         {
             fixed (char* ptrSource = source)
@@ -440,6 +444,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2)
         {
             EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
@@ -451,6 +456,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2, IntPtr a3, int size3)
         {
             EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
@@ -464,6 +470,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2,
             IntPtr a3, int size3, IntPtr a4, int size4)
         {
@@ -480,6 +487,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2,
             IntPtr a3, int size3, IntPtr a4, int size4, IntPtr a5, int size5)
         {
@@ -498,6 +506,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2,
             IntPtr a3, int size3, IntPtr a4, int size4, IntPtr a5, int size5, IntPtr a6, int size6)
         {
@@ -518,6 +527,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2,
             IntPtr a3, int size3, IntPtr a4, int size4, IntPtr a5, int size5, IntPtr a6, int size6,
             IntPtr a7, int size7)
@@ -541,6 +551,7 @@ namespace Microsoft.Azure.Amqp
         }
 
         [NonEvent]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026", Justification = EventSourceSuppressMessage)]
         unsafe void WriteEvent(int eventId, IntPtr a1, int size1, IntPtr a2, int size2,
             IntPtr a3, int size3, IntPtr a4, int size4, IntPtr a5, int size5, IntPtr a6, int size6,
             IntPtr a7, int size7, IntPtr a8, int size8)

--- a/src/Microsoft.Azure.Amqp.csproj
+++ b/src/Microsoft.Azure.Amqp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Microsoft.Azure.Amqp Class Library</Description>
@@ -22,7 +22,9 @@
     <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     <Configurations>Debug;Release;Signed</Configurations>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
+    <IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Serialization/AmqpContractSerializer.cs
+++ b/src/Serialization/AmqpContractSerializer.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Amqp.Serialization
     using System.Collections;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using System.Reflection;
@@ -18,6 +19,9 @@ namespace Microsoft.Azure.Amqp.Serialization
     /// </summary>
     public sealed class AmqpContractSerializer
     {
+        internal const string TrimWarning = "AmqpContractSerializer relies on reflection-based serialization. Required types may be removed when trimming.";
+        internal const string AotWarning = "AmqpContractSerializer relies on dynamically creating types that may not be available with Ahead of Time compilation.";
+
         static readonly Dictionary<Type, SerializableType> builtInTypes = new Dictionary<Type, SerializableType>()
         {
             { typeof(bool),     SerializableType.CreatePrimitiveType(typeof(bool)) },
@@ -91,6 +95,8 @@ namespace Microsoft.Azure.Amqp.Serialization
         /// </summary>
         /// <param name="stream">The destination stream.</param>
         /// <param name="graph">The object to serialize.</param>
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         public static void WriteObject(Stream stream, object graph)
         {
             if (graph == null)
@@ -114,6 +120,8 @@ namespace Microsoft.Azure.Amqp.Serialization
         /// <typeparam name="T">The expected type.</typeparam>
         /// <param name="stream">The source stream.</param>
         /// <returns>An object of T.</returns>
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         public static T ReadObject<T>(Stream stream)
         {
             return ReadObject<T, T>(stream);
@@ -128,6 +136,8 @@ namespace Microsoft.Azure.Amqp.Serialization
         /// <returns>An object of TAs.</returns>
         /// <remarks>The serializer uses T to resolve decoding
         /// types and returns the decoded object as TAs.</remarks>
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         public static TAs ReadObject<T, TAs>(Stream stream)
         {
             if (!stream.CanSeek)
@@ -168,6 +178,8 @@ namespace Microsoft.Azure.Amqp.Serialization
         /// </summary>
         /// <param name="buffer"></param>
         /// <param name="graph"></param>
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         public void WriteObjectToBuffer(ByteBuffer buffer, object graph)
         {
             if (graph == null)
@@ -187,6 +199,8 @@ namespace Microsoft.Azure.Amqp.Serialization
         /// <typeparam name="T">The expected type.</typeparam>
         /// <param name="buffer">The source buffer.</param>
         /// <returns>An object of T.</returns>
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         public T ReadObjectFromBuffer<T>(ByteBuffer buffer)
         {
             return this.ReadObjectFromBuffer<T, T>(buffer);
@@ -201,12 +215,16 @@ namespace Microsoft.Azure.Amqp.Serialization
         /// <returns>An object of TAs.</returns>
         /// <remarks>The serializer uses T to resolve decoding
         /// types and returns the decoded object as TAs.</remarks>
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         public TAs ReadObjectFromBuffer<T, TAs>(ByteBuffer buffer)
         {
             SerializableType type = this.GetType(typeof(T));
             return (TAs)type.ReadObject(buffer);
         }
 
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         internal SerializableType GetType(Type type)
         {
             return this.GetOrCompileType(type, false);
@@ -227,6 +245,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             return false;
         }
 
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         SerializableType GetOrCompileType(Type type, bool describedOnly)
         {
             SerializableType serialiableType = null;
@@ -247,6 +267,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             return serialiableType;
         }
 
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         SerializableType CompileType(Type type, bool describedOnly)
         {
             if (this.externalCompilers != null)
@@ -395,6 +417,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(TrimWarning)]
+        [RequiresDynamicCode(AotWarning)]
         SerializableType CompileNonContractTypes(Type type)
         {
             if (type.GetTypeInfo().IsGenericType &&

--- a/src/Serialization/MemberAccessor.cs
+++ b/src/Serialization/MemberAccessor.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Amqp.Serialization
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
 
     abstract class MemberAccessor
@@ -22,6 +23,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             get { return this.type; }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.TrimWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         public static MemberAccessor Create(MemberInfo memberInfo, bool requiresSetter)
         {
             FieldInfo fieldInfo;
@@ -48,6 +51,7 @@ namespace Microsoft.Azure.Amqp.Serialization
             this.setter(container, value);
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.TrimWarning)]
         sealed class FieldMemberAccessor : MemberAccessor
         {
             public FieldMemberAccessor(FieldInfo fieldInfo)
@@ -58,6 +62,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.TrimWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         sealed class PropertyMemberAccessor : MemberAccessor
         {
             public PropertyMemberAccessor(PropertyInfo propertyInfo, bool requiresSetter)

--- a/src/Serialization/MethodAccessor.cs
+++ b/src/Serialization/MethodAccessor.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Amqp.Serialization
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
 
     delegate object MethodDelegate(object container, object[] parameters);
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.Amqp.Serialization
         bool isStatic;
         MethodDelegate methodDelegate;
 
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         public static MethodAccessor Create(MethodInfo methodInfo)
         {
             return new TypeMethodAccessor(methodInfo);
@@ -54,6 +56,7 @@ namespace Microsoft.Azure.Amqp.Serialization
 
         sealed class TypeMethodAccessor : MethodAccessor
         {
+            [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
             public TypeMethodAccessor(MethodInfo methodInfo)
             {
                 this.isStatic = methodInfo.IsStatic;

--- a/src/Serialization/ReflectionExtentions.cs
+++ b/src/Serialization/ReflectionExtentions.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Amqp.Serialization
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using System.Runtime.Serialization;
 
@@ -25,6 +26,7 @@ namespace Microsoft.Azure.Amqp.Serialization
             return (obj, val) => fieldInfo.SetValue(obj, val);
         }
 
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         public static Func<object, object> CreateGetter(this PropertyInfo propertyInfo)
         {
             MethodInfo getMethod = propertyInfo.GetGetMethod(true);
@@ -33,6 +35,7 @@ namespace Microsoft.Azure.Amqp.Serialization
             return (Func<object, object>)m2.Invoke(null, new object[] { getMethod });
         }
 
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         public static Action<object, object> CreateSetter(this PropertyInfo propertyInfo, bool requiresSetter)
         {
             if (requiresSetter && propertyInfo.DeclaringType.IsValueType)
@@ -63,6 +66,7 @@ namespace Microsoft.Azure.Amqp.Serialization
             throw new NotImplementedException();
         }
 
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         public static MethodDelegate CreateMethod(this MethodInfo methodInfo, bool isStatic)
         {
             var parameters = methodInfo.GetParameters();

--- a/src/Serialization/SerializableType.cs
+++ b/src/Serialization/SerializableType.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Amqp.Serialization
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Reflection;
     using System.Runtime.Serialization;
     using Microsoft.Azure.Amqp.Encoding;
@@ -299,6 +300,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.TrimWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         internal sealed class List : Collection
         {
             readonly SerializableType itemType;
@@ -376,6 +379,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.TrimWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         internal sealed class Map : Collection
         {
             readonly SerializableType keyType;
@@ -451,6 +456,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.AotWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         internal abstract class Composite : Collection
         {
             readonly Composite baseType;
@@ -625,6 +632,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.AotWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         internal sealed class CompositeList : Composite
         {
             public CompositeList(
@@ -682,6 +691,8 @@ namespace Microsoft.Azure.Amqp.Serialization
             }
         }
 
+        [RequiresUnreferencedCode(AmqpContractSerializer.AotWarning)]
+        [RequiresDynamicCode(AmqpContractSerializer.AotWarning)]
         internal sealed class CompositeMap : Composite
         {
             public CompositeMap(

--- a/src/TrimmingAttributes.cs
+++ b/src/TrimmingAttributes.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+namespace System.Diagnostics.CodeAnalysis;
+
+#if !NET7_0_OR_GREATER
+/// <summary>
+/// Indicates that the specified method requires the ability to generate new code at runtime,
+/// for example through <see cref="System.Reflection"/>.
+/// </summary>
+/// <remarks>
+/// This allows tools to understand which methods are unsafe to call when compiling ahead of time.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+internal sealed class RequiresDynamicCodeAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiresDynamicCodeAttribute"/> class
+    /// with the specified message.
+    /// </summary>
+    /// <param name="message">
+    /// A message that contains information about the usage of dynamic code.
+    /// </param>
+    public RequiresDynamicCodeAttribute(string message)
+    {
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets a message that contains information about the usage of dynamic code.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets or sets an optional URL that contains more information about the method,
+    /// why it requires dynamic code, and what options a consumer has to deal with it.
+    /// </summary>
+    public string? Url { get; set; }
+}
+#endif
+
+#if !NET5_0_OR_GREATER
+/// <summary>
+/// Indicates that the specified method requires dynamic access to code that is not referenced
+/// statically, for example through <see cref="System.Reflection"/>.
+/// </summary>
+/// <remarks>
+/// This allows tools to understand which methods are unsafe to call when removing unreferenced
+/// code from an application.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+    /// with the specified message.
+    /// </summary>
+    /// <param name="message">
+    /// A message that contains information about the usage of unreferenced code.
+    /// </param>
+    public RequiresUnreferencedCodeAttribute(string message)
+    {
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets a message that contains information about the usage of unreferenced code.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets or sets an optional URL that contains more information about the method,
+    /// why it requires unreferenced code, and what options a consumer has to deal with it.
+    /// </summary>
+    public string? Url { get; set; }
+}
+
+/// <summary>
+/// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+/// single code artifact.
+/// </summary>
+/// <remarks>
+/// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+/// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+/// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+/// </remarks>
+[AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+    /// class, specifying the category of the tool and the identifier for an analysis rule.
+    /// </summary>
+    /// <param name="category">The category for the attribute.</param>
+    /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+    public UnconditionalSuppressMessageAttribute(string category, string checkId)
+    {
+        Category = category;
+        CheckId = checkId;
+    }
+
+    /// <summary>
+    /// Gets the category identifying the classification of the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Category"/> property describes the tool or tool analysis category
+    /// for which a message suppression attribute applies.
+    /// </remarks>
+    public string Category { get; }
+
+    /// <summary>
+    /// Gets the identifier of the analysis tool rule to be suppressed.
+    /// </summary>
+    /// <remarks>
+    /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+    /// properties form a unique check identifier.
+    /// </remarks>
+    public string CheckId { get; }
+
+    /// <summary>
+    /// Gets or sets the scope of the code that is relevant for the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The Scope property is an optional argument that specifies the metadata scope for which
+    /// the attribute is relevant.
+    /// </remarks>
+    public string? Scope { get; set; }
+
+    /// <summary>
+    /// Gets or sets a fully qualified path that represents the target of the attribute.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+    /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+    /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+    /// The analysis tool user interface should be capable of automatically formatting the parameter.
+    /// </remarks>
+    public string? Target { get; set; }
+
+    /// <summary>
+    /// Gets or sets an optional argument expanding on exclusion criteria.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+    /// exclusion where the literal metadata target is not sufficiently precise. For example,
+    /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+    /// and it may be desirable to suppress a violation against a statement in the method that will
+    /// give a rule violation, but not against all statements in the method.
+    /// </remarks>
+    public string? MessageId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the justification for suppressing the code analysis message.
+    /// </summary>
+    public string? Justification { get; set; }
+}
+#endif


### PR DESCRIPTION
Adds annotations for trimming/AOT compatibility. The only warnings in this library were for EventSource (which could be suppressed because EventSource was only used with primitive types), and reflection-based serialization (where the warnings were bubbled up with RequiresUnreferencedCode/RequiresDynamicCode annotations).