### PR TITLE
Replace SegmentBufferPool with ArrayPool.Create

### DIFF
--- a/src/SegmentBufferPool.cs
+++ b/src/SegmentBufferPool.cs
@@ -4,22 +4,17 @@
 namespace Microsoft.Azure.Amqp
 {
     using System;
+    using System.Buffers;
 
     sealed class SegmentBufferPool
     {
+        readonly ArrayPool<byte> arrayPool;
         readonly int segmentSize;
-        readonly int maxCount;
-        readonly object lockObject;
-        byte[] heap;
-        int[] offsets;
-        int top;
 
         public SegmentBufferPool(int segmentSize, int maxCount)
         {
             this.segmentSize = segmentSize;
-            this.maxCount = maxCount;
-            this.lockObject = new object();
-            this.Initialize(4);
+            arrayPool = ArrayPool<byte>.Create(segmentSize, maxCount);
         }
 
         public int SegmentSize
@@ -34,20 +29,7 @@ namespace Microsoft.Azure.Amqp
                 throw new ArgumentOutOfRangeException(nameof(bufferSize));
             }
 
-            lock (this.lockObject)
-            {
-                if (this.top >= 0)
-                {
-                    return new ArraySegment<byte>(this.heap, this.offsets[this.top--], bufferSize);
-                }
-                else if (this.offsets.Length < this.maxCount)
-                {
-                    this.Initialize(Math.Min(this.offsets.Length * 2, this.maxCount));
-                    return new ArraySegment<byte>(this.heap, this.offsets[this.top--], bufferSize);
-                }
-            }
-
-            return new ArraySegment<byte>(new byte[bufferSize]);
+            return new ArraySegment<byte>(this.arrayPool.Rent(bufferSize), 0, bufferSize);
         }
 
         public void ReturnBuffer(ArraySegment<byte> buffer)
@@ -55,24 +37,7 @@ namespace Microsoft.Azure.Amqp
             Fx.Assert(buffer.Offset % this.segmentSize == 0, "invalid offset");
             Fx.Assert(buffer.Count <= this.segmentSize, "invalid size");
 
-            lock (this.lockObject)
-            {
-                if (buffer.Array == this.heap && this.top < this.offsets.Length - 1)
-                {
-                    this.offsets[++this.top] = buffer.Offset;
-                }
-            }
-        }
-
-        void Initialize(int count)
-        {
-            this.heap = new byte[segmentSize * count];
-            this.offsets = new int[count];
-            this.top = count - 1;
-            for (int i = count - 1, offset = 0; i >= 0; --i, offset += segmentSize)
-            {
-                this.offsets[i] = offset;
-            }
+            arrayPool.Return(buffer.Array);
         }
     }
 }


### PR DESCRIPTION
Additional modifications similar to https://github.com/Azure/azure-amqp/pull/182

This pull request refactors the buffer management system by replacing the custom `SegmentBufferPool` implementation with the more efficient and standardized `ArrayPool<byte>` from `System.Buffers`. This change simplifies the codebase and makes it possible to benefit from improvements across the runtime implementation, as well as the ability to benefit from [built-in diagnostics.](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/well-known-event-providers) 

This also gets rid of the custom locking