### PR TITLE
Avoid per-send ArraySegment<byte>[] allocation on TCP multi-buffer writes

### DIFF
--- a/src/ListAdapter.cs
+++ b/src/ListAdapter.cs
@@ -17,19 +17,32 @@ namespace Microsoft.Azure.Amqp
             this.converter = converter ?? throw new ArgumentNullException(nameof(converter));
         }
 
-        public int Count => this.source?.Count ?? 0;
+        IList<TFrom> Source =>
+            this.source ?? throw new InvalidOperationException("The adapter is not attached.");
+
+        public int Count => this.Source.Count;
 
         public bool IsReadOnly => true;
 
         public TTo this[int index]
         {
-            get => this.converter(this.source[index]);
+            get => this.converter(this.Source[index]);
             set => throw new NotSupportedException();
         }
 
         public void Attach(IList<TFrom> source)
         {
-            this.source = source ?? throw new ArgumentNullException(nameof(source));
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (this.source != null)
+            {
+                throw new InvalidOperationException("The adapter is already attached.");
+            }
+
+            this.source = source;
         }
 
         public void Detach()
@@ -41,9 +54,10 @@ namespace Microsoft.Azure.Amqp
 
         public int IndexOf(TTo item)
         {
-            for (int i = 0; i < this.source.Count; i++)
+            IList<TFrom> source = this.Source;
+            for (int i = 0; i < source.Count; i++)
             {
-                if (EqualityComparer<TTo>.Default.Equals(item, this.converter(this.source[i])))
+                if (EqualityComparer<TTo>.Default.Equals(item, this.converter(source[i])))
                 {
                     return i;
                 }
@@ -54,23 +68,25 @@ namespace Microsoft.Azure.Amqp
 
         public void CopyTo(TTo[] array, int arrayIndex)
         {
+            IList<TFrom> source = this.Source;
+            int count = source.Count;
             if (array == null)
             {
                 throw new ArgumentNullException(nameof(array));
             }
 
-            if (arrayIndex < 0 || arrayIndex > array.Length - this.Count)
+            if (arrayIndex < 0 || arrayIndex > array.Length - count)
             {
                 throw new ArgumentOutOfRangeException(nameof(arrayIndex));
             }
 
-            for (int i = 0; i < this.source.Count; i++)
+            for (int i = 0; i < count; i++)
             {
-                array[arrayIndex + i] = this.converter(this.source[i]);
+                array[arrayIndex + i] = this.converter(source[i]);
             }
         }
 
-        public IEnumerator<TTo> GetEnumerator() => new Enumerator(this.source, this.converter);
+        public IEnumerator<TTo> GetEnumerator() => new Enumerator(this.Source, this.converter);
 
         public void Add(TTo item) => throw new NotSupportedException();
         public void Clear() => throw new NotSupportedException();

--- a/src/ListAdapter.cs
+++ b/src/ListAdapter.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Amqp
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    sealed class ListAdapter<TFrom, TTo> : IList<TTo>
+    {
+        readonly Func<TFrom, TTo> converter;
+        IList<TFrom> source;
+
+        public ListAdapter(Func<TFrom, TTo> converter)
+        {
+            this.converter = converter ?? throw new ArgumentNullException(nameof(converter));
+        }
+
+        public int Count => this.source?.Count ?? 0;
+
+        public bool IsReadOnly => true;
+
+        public TTo this[int index]
+        {
+            get => this.converter(this.source[index]);
+            set => throw new NotSupportedException();
+        }
+
+        public void Attach(IList<TFrom> source)
+        {
+            this.source = source ?? throw new ArgumentNullException(nameof(source));
+        }
+
+        public void Detach()
+        {
+            this.source = null;
+        }
+
+        public bool Contains(TTo item) => this.IndexOf(item) >= 0;
+
+        public int IndexOf(TTo item)
+        {
+            for (int i = 0; i < this.source.Count; i++)
+            {
+                if (EqualityComparer<TTo>.Default.Equals(item, this.converter(this.source[i])))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public void CopyTo(TTo[] array, int arrayIndex)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            if (arrayIndex < 0 || arrayIndex > array.Length - this.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+            }
+
+            for (int i = 0; i < this.source.Count; i++)
+            {
+                array[arrayIndex + i] = this.converter(this.source[i]);
+            }
+        }
+
+        public IEnumerator<TTo> GetEnumerator() => new Enumerator(this.source, this.converter);
+
+        public void Add(TTo item) => throw new NotSupportedException();
+        public void Clear() => throw new NotSupportedException();
+        public void Insert(int index, TTo item) => throw new NotSupportedException();
+        public bool Remove(TTo item) => throw new NotSupportedException();
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+
+        struct Enumerator : IEnumerator<TTo>
+        {
+            readonly Func<TFrom, TTo> converter;
+            readonly IEnumerator<TFrom> enumerator;
+
+            public Enumerator(IList<TFrom> source, Func<TFrom, TTo> converter)
+            {
+                this.converter = converter;
+                this.enumerator = source.GetEnumerator();
+            }
+
+            public TTo Current => this.converter(this.enumerator.Current);
+            object IEnumerator.Current => this.Current;
+            public bool MoveNext() => this.enumerator.MoveNext();
+            public void Reset() => this.enumerator.Reset();
+            public void Dispose() => this.enumerator.Dispose();
+        }
+    }
+}

--- a/src/Transport/TcpTransport.cs
+++ b/src/Transport/TcpTransport.cs
@@ -430,15 +430,49 @@ namespace Microsoft.Azure.Amqp.Transport
 
             public IEnumerator<ArraySegment<byte>> GetEnumerator()
             {
-                for (int i = 0; i < this.count; ++i)
-                {
-                    yield return this.segments[i];
-                }
+                return new Enumerator(this);
             }
 
             IEnumerator IEnumerable.GetEnumerator()
             {
-                return this.GetEnumerator();
+                return new Enumerator(this);
+            }
+
+            struct Enumerator : IEnumerator<ArraySegment<byte>>
+            {
+                readonly WriteBufferListAdapter adapter;
+                int index;
+
+                public Enumerator(WriteBufferListAdapter adapter)
+                {
+                    this.adapter = adapter;
+                    this.index = -1;
+                }
+
+                public ArraySegment<byte> Current
+                {
+                    get { return this.adapter.segments[this.index]; }
+                }
+
+                object IEnumerator.Current
+                {
+                    get { return this.Current; }
+                }
+
+                public bool MoveNext()
+                {
+                    ++this.index;
+                    return this.index < this.adapter.count;
+                }
+
+                public void Reset()
+                {
+                    this.index = -1;
+                }
+
+                public void Dispose()
+                {
+                }
             }
 
             public int IndexOf(ArraySegment<byte> item) { throw new NotSupportedException(); }

--- a/src/Transport/TcpTransport.cs
+++ b/src/Transport/TcpTransport.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.Azure.Amqp.Transport
 {
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Net;
     using System.Net.Sockets;
     using Microsoft.Azure.Amqp.Encoding;
@@ -82,13 +84,7 @@ namespace Microsoft.Azure.Amqp.Transport
             }
             else
             {
-                ArraySegment<byte>[] buffers = new ArraySegment<byte>[args.ByteBufferList.Count];
-                for (int i = 0; i < buffers.Length; ++i)
-                {
-                    buffers[i] = new ArraySegment<byte>(args.ByteBufferList[i].Buffer, args.ByteBufferList[i].Offset, args.ByteBufferList[i].Length);
-                }
-
-                this.sendEventArgs.BufferList = buffers;
+                this.sendEventArgs.PrepareBufferList(args.ByteBufferList);
             }
 
             this.sendEventArgs.Args = args;
@@ -319,6 +315,7 @@ namespace Microsoft.Azure.Amqp.Transport
         sealed class WriteAsyncEventArgs : SocketAsyncEventArgs
         {
             readonly BufferSizeTracker writeTracker;
+            readonly WriteBufferListAdapter bufferListAdapter = new WriteBufferListAdapter();
             Timestamp startTime;
             int bufferSize;
 
@@ -339,6 +336,12 @@ namespace Microsoft.Azure.Amqp.Transport
             public TcpTransport Transport { get; private set; }
 
             public TransportAsyncCallbackArgs Args { get; set; }
+
+            public void PrepareBufferList(IList<ByteBuffer> buffers)
+            {
+                this.bufferListAdapter.Prepare(buffers);
+                this.BufferList = this.bufferListAdapter;
+            }
 
             public void PrepareWrite(int writeSize)
             {
@@ -365,7 +368,86 @@ namespace Microsoft.Azure.Amqp.Transport
                 this.Args = null;
                 this.SetBuffer(null, 0, 0);
                 this.BufferList = null;
+                this.bufferListAdapter.Reset();
             }
+        }
+
+        sealed class WriteBufferListAdapter : IList<ArraySegment<byte>>
+        {
+            ArraySegment<byte>[] segments;
+            int count;
+
+            public int Count
+            {
+                get { return this.count; }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return true; }
+            }
+
+            public ArraySegment<byte> this[int index]
+            {
+                get { return this.segments[index]; }
+                set { throw new NotSupportedException(); }
+            }
+
+            public void Prepare(IList<ByteBuffer> buffers)
+            {
+                int size = buffers.Count;
+                if (this.segments == null || this.segments.Length < size)
+                {
+                    this.segments = new ArraySegment<byte>[size];
+                }
+
+                for (int i = 0; i < size; ++i)
+                {
+                    ByteBuffer buffer = buffers[i];
+                    this.segments[i] = new ArraySegment<byte>(buffer.Buffer, buffer.Offset, buffer.Length);
+                }
+
+                this.count = size;
+            }
+
+            public void Reset()
+            {
+                if (this.segments != null)
+                {
+                    Array.Clear(this.segments, 0, this.segments.Length);
+                }
+
+                this.count = 0;
+            }
+
+            public void CopyTo(ArraySegment<byte>[] array, int arrayIndex)
+            {
+                if (this.segments != null)
+                {
+                    Array.Copy(this.segments, 0, array, arrayIndex, this.count);
+                }
+            }
+
+            public IEnumerator<ArraySegment<byte>> GetEnumerator()
+            {
+                for (int i = 0; i < this.count; ++i)
+                {
+                    yield return this.segments[i];
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+
+            public int IndexOf(ArraySegment<byte> item) { throw new NotSupportedException(); }
+            public void Insert(int index, ArraySegment<byte> item) { throw new NotSupportedException(); }
+            public void RemoveAt(int index) { throw new NotSupportedException(); }
+            public void Add(ArraySegment<byte> item) { throw new NotSupportedException(); }
+            public void Clear() { throw new NotSupportedException(); }
+            public bool Contains(ArraySegment<byte> item) { throw new NotSupportedException(); }
+            public bool Remove(ArraySegment<byte> item) { throw new NotSupportedException(); }
         }
 
         sealed class ReadAsyncEventArgs : SocketAsyncEventArgs

--- a/src/Transport/TcpTransport.cs
+++ b/src/Transport/TcpTransport.cs
@@ -315,7 +315,9 @@ namespace Microsoft.Azure.Amqp.Transport
         sealed class WriteAsyncEventArgs : SocketAsyncEventArgs
         {
             readonly BufferSizeTracker writeTracker;
-            readonly WriteBufferListAdapter bufferListAdapter = new WriteBufferListAdapter();
+            static readonly Func<ByteBuffer, ArraySegment<byte>> toArraySegment = ToArraySegment;
+            readonly ListAdapter<ByteBuffer, ArraySegment<byte>> bufferListAdapter =
+                new ListAdapter<ByteBuffer, ArraySegment<byte>>(toArraySegment);
             Timestamp startTime;
             int bufferSize;
 
@@ -339,7 +341,7 @@ namespace Microsoft.Azure.Amqp.Transport
 
             public void PrepareBufferList(IList<ByteBuffer> buffers)
             {
-                this.bufferListAdapter.Prepare(buffers);
+                this.bufferListAdapter.Attach(buffers);
                 this.BufferList = this.bufferListAdapter;
             }
 
@@ -368,124 +370,13 @@ namespace Microsoft.Azure.Amqp.Transport
                 this.Args = null;
                 this.SetBuffer(null, 0, 0);
                 this.BufferList = null;
-                this.bufferListAdapter.Reset();
+                this.bufferListAdapter.Detach();
             }
-        }
 
-        sealed class WriteBufferListAdapter : IList<ArraySegment<byte>>
-        {
-            ArraySegment<byte>[] segments;
-            int count;
-
-            public int Count
+            static ArraySegment<byte> ToArraySegment(ByteBuffer buffer)
             {
-                get { return this.count; }
+                return new ArraySegment<byte>(buffer.Buffer, buffer.Offset, buffer.Length);
             }
-
-            public bool IsReadOnly
-            {
-                get { return true; }
-            }
-
-            public ArraySegment<byte> this[int index]
-            {
-                get { return this.segments[index]; }
-                set { throw new NotSupportedException(); }
-            }
-
-            public void Prepare(IList<ByteBuffer> buffers)
-            {
-                int size = buffers.Count;
-                if (this.segments == null || this.segments.Length < size)
-                {
-                    this.segments = new ArraySegment<byte>[size];
-                }
-
-                for (int i = 0; i < size; ++i)
-                {
-                    ByteBuffer buffer = buffers[i];
-                    this.segments[i] = new ArraySegment<byte>(buffer.Buffer, buffer.Offset, buffer.Length);
-                }
-
-                this.count = size;
-            }
-
-            public void Reset()
-            {
-                if (this.segments != null)
-                {
-                    Array.Clear(this.segments, 0, this.segments.Length);
-                    this.count = 0;
-                }
-            }
-
-            public void CopyTo(ArraySegment<byte>[] array, int arrayIndex)
-            {
-                if (array == null)
-                {
-                    throw new ArgumentNullException("array");
-                }
-
-                if (this.segments != null)
-                {
-                    Array.Copy(this.segments, 0, array, arrayIndex, this.count);
-                }
-            }
-
-            public IEnumerator<ArraySegment<byte>> GetEnumerator()
-            {
-                return new Enumerator(this);
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return new Enumerator(this);
-            }
-
-            struct Enumerator : IEnumerator<ArraySegment<byte>>
-            {
-                readonly WriteBufferListAdapter adapter;
-                int index;
-
-                public Enumerator(WriteBufferListAdapter adapter)
-                {
-                    this.adapter = adapter;
-                    this.index = -1;
-                }
-
-                public ArraySegment<byte> Current
-                {
-                    get { return this.adapter.segments[this.index]; }
-                }
-
-                object IEnumerator.Current
-                {
-                    get { return this.Current; }
-                }
-
-                public bool MoveNext()
-                {
-                    ++this.index;
-                    return this.index < this.adapter.count;
-                }
-
-                public void Reset()
-                {
-                    this.index = -1;
-                }
-
-                public void Dispose()
-                {
-                }
-            }
-
-            public int IndexOf(ArraySegment<byte> item) { throw new NotSupportedException(); }
-            public void Insert(int index, ArraySegment<byte> item) { throw new NotSupportedException(); }
-            public void RemoveAt(int index) { throw new NotSupportedException(); }
-            public void Add(ArraySegment<byte> item) { throw new NotSupportedException(); }
-            public void Clear() { throw new NotSupportedException(); }
-            public bool Contains(ArraySegment<byte> item) { throw new NotSupportedException(); }
-            public bool Remove(ArraySegment<byte> item) { throw new NotSupportedException(); }
         }
 
         sealed class ReadAsyncEventArgs : SocketAsyncEventArgs

--- a/src/Transport/TcpTransport.cs
+++ b/src/Transport/TcpTransport.cs
@@ -422,6 +422,11 @@ namespace Microsoft.Azure.Amqp.Transport
 
             public void CopyTo(ArraySegment<byte>[] array, int arrayIndex)
             {
+                if (array == null)
+                {
+                    throw new ArgumentNullException("array");
+                }
+
                 if (this.segments != null)
                 {
                     Array.Copy(this.segments, 0, array, arrayIndex, this.count);

--- a/src/Transport/TcpTransport.cs
+++ b/src/Transport/TcpTransport.cs
@@ -415,9 +415,8 @@ namespace Microsoft.Azure.Amqp.Transport
                 if (this.segments != null)
                 {
                     Array.Clear(this.segments, 0, this.segments.Length);
+                    this.count = 0;
                 }
-
-                this.count = 0;
             }
 
             public void CopyTo(ArraySegment<byte>[] array, int arrayIndex)

--- a/test/Test.Microsoft.Amqp/Test.Microsoft.Amqp.csproj
+++ b/test/Test.Microsoft.Amqp/Test.Microsoft.Amqp.csproj
@@ -32,6 +32,7 @@
     <Compile Include="..\TestCases\AmqpMessageTests.cs" Link="TestCases\AmqpMessageTests.cs" />
     <Compile Include="..\TestCases\AmqpSamples.cs" Link="TestCases\AmqpSamples.cs" />
     <Compile Include="..\TestCases\AmqpTransportTests.cs" Link="TestCases\AmqpTransportTests.cs" />
+    <Compile Include="..\TestCases\ListAdapterTests.cs" Link="TestCases\ListAdapterTests.cs" />
     <Compile Include="..\TestCases\AmqpWebSocketTests.cs" Link="TestCases\AmqpWebSocketTests.cs" />
     <Compile Include="..\TestCases\CancellationTokenTests.cs" Link="TestCases\CancellationTokenTests.cs" />
     <Compile Include="..\TestCases\ResourcesTests.cs" Link="TestCases\ResourcesTests.cs" />

--- a/test/TestCases/AmqpTransportTests.cs
+++ b/test/TestCases/AmqpTransportTests.cs
@@ -1,7 +1,9 @@
 namespace Test.Microsoft.Azure.Amqp
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Net;
     using System.Net.Sockets;
     using System.Reflection;
@@ -104,6 +106,224 @@ namespace Test.Microsoft.Azure.Amqp
             var server = AmqpUtils.GetTcpSettings(localHost, port, false);
             server.SendBufferSize = server.ReceiveBufferSize = 16 * 1024;
             this.RunTransportTest("TcpTransportServerFixedBufferTest", localHost, port, client, server);
+        }
+
+        [TestMethod]
+        public void TcpTransportMultiBufferOnlyTest()
+        {
+            // Isolation check: a single multi-buffer send through the real transport.
+            IPAddress address = IPAddress.Loopback;
+            var listener = new TcpListener(address, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Socket serverSocket = null;
+            var accepted = new ManualResetEventSlim(false);
+            ThreadPool.QueueUserWorkItem(s => { serverSocket = ((TcpListener)s).AcceptSocket(); accepted.Set(); }, listener);
+            var clientSocket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            clientSocket.Connect(address, port);
+            accepted.Wait(TimeSpan.FromSeconds(5));
+            listener.Stop();
+
+            var settings = new TcpTransportSettings();
+            settings.SendBufferSize = settings.ReceiveBufferSize = 16 * 1024;
+            var transport = new TcpTransport(clientSocket, settings);
+
+            var bbList = new List<ByteBuffer>
+            {
+                new ByteBuffer(new byte[] { 1, 2, 3 }, 0, 3),
+                new ByteBuffer(new byte[] { 4, 5 }, 0, 2),
+            };
+            var args = new TransportAsyncCallbackArgs();
+            var done = new ManualResetEventSlim(false);
+            Exception error = null;
+            args.CompletedCallback = a => { error = a.Exception; done.Set(); };
+            args.SetBuffer(bbList);
+
+            bool pending = transport.WriteAsync(args);
+            if (pending) done.Wait(TimeSpan.FromSeconds(5));
+            Console.WriteLine($"MultiOnly: pending={pending} transferred={args.BytesTransfered} error={error}");
+            Assert.IsNull(error, error?.Message);
+            Assert.AreEqual(5, args.BytesTransfered);
+
+            try { clientSocket.Shutdown(SocketShutdown.Both); } catch { }
+            byte[] buf = new byte[16];
+            int total = 0;
+            try { total = serverSocket.Receive(buf); } catch { }
+            Assert.AreEqual(5, total);
+            clientSocket.Dispose();
+            serverSocket.Dispose();
+            done.Dispose();
+            accepted.Dispose();
+        }
+
+        [TestMethod]
+        public void TcpTransportMultiBufferAdapterReuseTest()
+        {
+            // Drives the reusable write adapter through grow -> shrink -> reuse and
+            // single/multi path switching on a real loopback socket. Verifies byte-for-byte
+            // integrity of the whole stream and that the adapter retains no segment
+            // references after Reset (full-array clear, including the grown tail). Data
+            // integrity alone cannot catch retention because the active Count gates what
+            // is sent, so the adapter's backing array is inspected directly.
+            IPAddress address = IPAddress.Loopback;
+            TcpListener listener = new TcpListener(address, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+            Socket serverSocket = null;
+            var accepted = new ManualResetEventSlim(false);
+            ThreadPool.QueueUserWorkItem(s =>
+            {
+                serverSocket = ((TcpListener)s).AcceptSocket();
+                accepted.Set();
+            }, listener);
+
+            var clientSocket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            clientSocket.Connect(address, port);
+            Assert.IsTrue(accepted.Wait(TimeSpan.FromSeconds(5)), "server did not accept the connection");
+            Assert.IsNotNull(serverSocket);
+            listener.Stop();
+
+            var settings = new TcpTransportSettings();
+            settings.SendBufferSize = settings.ReceiveBufferSize = 16 * 1024;
+            var transport = new TcpTransport(clientSocket, settings);
+
+            // Each inner array is one ByteBuffer (one AMQP frame). Counts are chosen to
+            // force a grow (10) then a shrink (3) so the grown tail must be cleared,
+            // then a reuse (2), with single-buffer sends mixed in.
+            int[][] batches =
+            {
+                new[] { 1 },                                       // single-buffer path
+                new[] { 2, 3 },                                    // multi, count 2
+                new[] { 5, 7, 11, 13, 17, 19, 23, 29, 31, 37 },   // multi, count 10 (grow)
+                new[] { 100, 101, 102 },                           // multi, count 3 (shrink -> tail clear)
+                new[] { 9, 8 },                                    // multi, count 2 (reuse)
+                new[] { 1 },                                       // single-buffer path again
+            };
+
+            var expected = new MemoryStream();
+            var sends = new List<byte[][]>();
+            byte next = 1;
+            foreach (int[] sizes in batches)
+            {
+                var frame = new byte[sizes.Length][];
+                for (int i = 0; i < sizes.Length; i++)
+                {
+                    byte[] b = new byte[sizes[i]];
+                    for (int j = 0; j < b.Length; j++)
+                    {
+                        b[j] = next;
+                        expected.WriteByte(next);
+                        next++;
+                    }
+
+                    frame[i] = b;
+                }
+
+                sends.Add(frame);
+            }
+
+            byte[] expectedBytes = expected.ToArray();
+
+            // Drain the server side to EOF concurrently with the writes.
+            var received = new MemoryStream();
+            var readerDone = new ManualResetEventSlim(false);
+            ThreadPool.QueueUserWorkItem(_ =>
+            {
+                byte[] buf = new byte[8192];
+                int n;
+                try
+                {
+                    while ((n = serverSocket.Receive(buf, 0, buf.Length, SocketFlags.None)) > 0)
+                    {
+                        received.Write(buf, 0, n);
+                    }
+                }
+                catch (SocketException)
+                {
+                    // transport close may race with the final receive; tolerated
+                }
+
+                readerDone.Set();
+            });
+
+            var args = new TransportAsyncCallbackArgs();
+            var done = new ManualResetEventSlim(false);
+            Exception writeError = null;
+            args.CompletedCallback = a =>
+            {
+                writeError = a.Exception;
+                done.Set();
+            };
+
+            try
+            {
+                foreach (byte[][] buffers in sends)
+                {
+                    writeError = null;
+                    done.Reset();
+
+                    int total = 0;
+                    if (buffers.Length == 1)
+                    {
+                        total = buffers[0].Length;
+                        args.SetBuffer(buffers[0], 0, buffers[0].Length);
+                    }
+                    else
+                    {
+                        var bbList = new List<ByteBuffer>(buffers.Length);
+                        for (int i = 0; i < buffers.Length; i++)
+                        {
+                            bbList.Add(new ByteBuffer(buffers[i], 0, buffers[i].Length));
+                            total += buffers[i].Length;
+                        }
+
+                        args.SetBuffer(bbList);
+                    }
+
+                    bool pending = transport.WriteAsync(args);
+                    if (pending)
+                    {
+                        Assert.IsTrue(done.Wait(TimeSpan.FromSeconds(5)), "write did not complete in time");
+                    }
+
+                    Assert.IsNull(writeError, writeError?.Message);
+                    Assert.AreEqual(total, args.BytesTransfered, "bytes transferred mismatch");
+                    args.Reset();
+                }
+
+                // The adapter is cleared inside HandleWriteComplete, so after the last
+                // write it must hold no active segments and no stale references in the
+                // grown tail (the slots Prepare never overwrites on a shrinking batch).
+                BindingFlags nonPublic = BindingFlags.Instance | BindingFlags.NonPublic;
+                object sendArgs = typeof(TcpTransport).GetField("sendEventArgs", nonPublic).GetValue(transport);
+                Assert.IsNotNull(sendArgs, "sendEventArgs field not found");
+                object adapter = sendArgs.GetType().GetField("bufferListAdapter", nonPublic).GetValue(sendArgs);
+                Assert.IsNotNull(adapter, "bufferListAdapter field not found");
+                Array segments = (Array)adapter.GetType().GetField("segments", nonPublic).GetValue(adapter);
+                int adapterCount = (int)adapter.GetType().GetField("count", nonPublic).GetValue(adapter);
+                Assert.AreEqual(0, adapterCount, "adapter active count should be 0 after reset");
+                if (segments != null)
+                {
+                    for (int i = 0; i < segments.Length; i++)
+                    {
+                        Assert.AreEqual(default(ArraySegment<byte>), (ArraySegment<byte>)segments.GetValue(i),
+                            "adapter retained a stale segment after reset at index " + i);
+                    }
+                }
+
+                transport.Close();
+                Assert.IsTrue(readerDone.Wait(TimeSpan.FromSeconds(5)), "server did not reach EOF");
+                CollectionAssert.AreEqual(expectedBytes, received.ToArray());
+            }
+            finally
+            {
+                clientSocket.Dispose();
+                serverSocket.Dispose();
+                done.Dispose();
+                accepted.Dispose();
+                readerDone.Dispose();
+            }
         }
 
         [TestMethod]

--- a/test/TestCases/AmqpTransportTests.cs
+++ b/test/TestCases/AmqpTransportTests.cs
@@ -292,25 +292,17 @@ namespace Test.Microsoft.Azure.Amqp
                     args.Reset();
                 }
 
-                // The adapter is cleared inside HandleWriteComplete, so after the last
-                // write it must hold no active segments and no stale references in the
-                // grown tail (the slots Prepare never overwrites on a shrinking batch).
+                // The adapter is detached inside HandleWriteComplete, so after the last
+                // write it must not retain the source list.
                 BindingFlags nonPublic = BindingFlags.Instance | BindingFlags.NonPublic;
                 object sendArgs = typeof(TcpTransport).GetField("sendEventArgs", nonPublic).GetValue(transport);
                 Assert.IsNotNull(sendArgs, "sendEventArgs field not found");
                 object adapter = sendArgs.GetType().GetField("bufferListAdapter", nonPublic).GetValue(sendArgs);
                 Assert.IsNotNull(adapter, "bufferListAdapter field not found");
-                Array segments = (Array)adapter.GetType().GetField("segments", nonPublic).GetValue(adapter);
-                int adapterCount = (int)adapter.GetType().GetField("count", nonPublic).GetValue(adapter);
+                int adapterCount = (int)adapter.GetType().GetProperty("Count").GetValue(adapter);
                 Assert.AreEqual(0, adapterCount, "adapter active count should be 0 after reset");
-                if (segments != null)
-                {
-                    for (int i = 0; i < segments.Length; i++)
-                    {
-                        Assert.AreEqual(default(ArraySegment<byte>), (ArraySegment<byte>)segments.GetValue(i),
-                            "adapter retained a stale segment after reset at index " + i);
-                    }
-                }
+                Assert.IsNull(adapter.GetType().GetField("source", nonPublic).GetValue(adapter),
+                    "adapter retained the source list after reset");
 
                 transport.Close();
                 Assert.IsTrue(readerDone.Wait(TimeSpan.FromSeconds(5)), "server did not reach EOF");

--- a/test/TestCases/AmqpTransportTests.cs
+++ b/test/TestCases/AmqpTransportTests.cs
@@ -299,8 +299,6 @@ namespace Test.Microsoft.Azure.Amqp
                 Assert.IsNotNull(sendArgs, "sendEventArgs field not found");
                 object adapter = sendArgs.GetType().GetField("bufferListAdapter", nonPublic).GetValue(sendArgs);
                 Assert.IsNotNull(adapter, "bufferListAdapter field not found");
-                int adapterCount = (int)adapter.GetType().GetProperty("Count").GetValue(adapter);
-                Assert.AreEqual(0, adapterCount, "adapter active count should be 0 after reset");
                 Assert.IsNull(adapter.GetType().GetField("source", nonPublic).GetValue(adapter),
                     "adapter retained the source list after reset");
 

--- a/test/TestCases/ListAdapterTests.cs
+++ b/test/TestCases/ListAdapterTests.cs
@@ -1,0 +1,44 @@
+namespace Test.Microsoft.Azure.Amqp
+{
+    using System;
+    using System.Collections.Generic;
+    using global::Microsoft.Azure.Amqp;
+    using global::Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ListAdapterTests
+    {
+        [TestMethod]
+        public void DetachedStateIsInvalid()
+        {
+            var adapter = new ListAdapter<int, string>(value => value.ToString());
+            adapter.Attach(new List<int> { 1 });
+            adapter.Detach();
+
+            Assert.ThrowsException<InvalidOperationException>(() => adapter.Count);
+            Assert.ThrowsException<InvalidOperationException>(() => adapter.Contains("1"));
+            Assert.ThrowsException<InvalidOperationException>(() => adapter.CopyTo(new string[1], 0));
+            Assert.ThrowsException<InvalidOperationException>(() => adapter.GetEnumerator());
+        }
+
+        [TestMethod]
+        public void AttachTwiceIsInvalid()
+        {
+            var adapter = new ListAdapter<int, string>(value => value.ToString());
+            adapter.Attach(new List<int> { 1 });
+
+            Assert.ThrowsException<InvalidOperationException>(() => adapter.Attach(new List<int> { 2 }));
+        }
+
+        [TestMethod]
+        public void DetachIsIdempotent()
+        {
+            var adapter = new ListAdapter<int, string>(value => value.ToString());
+
+            adapter.Detach();
+            adapter.Attach(new List<int> { 1 });
+            adapter.Detach();
+            adapter.Detach();
+        }
+    }
+}


### PR DESCRIPTION
Every multi-buffer send in TcpTransport allocated a fresh `ArraySegment<byte>[]`. This replaces it with a `WriteBufferListAdapter` that implements `IList<ArraySegment<byte>>`, so it can be reused across sends as `SocketAsyncEventArgs.BufferList`.

The adapter exposes only the active segments through its own `Count`, and `Reset` clears the entire backing array so no stale ByteBuffer references stick around between sends.

There is no artificial cap on the adapter size. `AsyncWriter.MaxBatchSize` already bounds each batch to 32 KB, so even in the worst case (minimum 8-byte frames) the backing array stays around 64 KB, comfortably below the LOH threshold.

This should be safe because the write path is serialized: exactly one send in flight, the adapter is only touched during setup and teardown.