### PR TITLE
Update to .NET 10 SDK and modernize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2022
+          - os: windows-2025
             name: Windows
       fail-fast: false
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v6.0.0
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       - name: Build
         shell: pwsh
         run: . .\build.ps1; Build-Solution -Configuration Release -Platform 'Any CPU'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/test/Test.Microsoft.Amqp/Test.Microsoft.Amqp.csproj
+++ b/test/Test.Microsoft.Amqp/Test.Microsoft.Amqp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
     <AssemblyName>Test.Microsoft.Amqp</AssemblyName>
     <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>

--- a/test/TestAmqpBroker/TestAmqpBroker.csproj
+++ b/test/TestAmqpBroker/TestAmqpBroker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/test/TestAmqpClient/TestAmqpClient.csproj
+++ b/test/TestAmqpClient/TestAmqpClient.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/test/TestCases/AmqpLinkTests.cs
+++ b/test/TestCases/AmqpLinkTests.cs
@@ -682,25 +682,26 @@ namespace Test.Microsoft.Azure.Amqp
             broker.AddQueue(entity);
 
             AmqpConnection connection = AmqpUtils.CreateConnection(addressUri, null, false, null, 65536);
-            connection.Open();
+            await connection.OpenAsync();
 
             AmqpSession session = connection.CreateSession(new AmqpSessionSettings());
-            session.Open();
+            await session.OpenAsync();
 
             SendingAmqpLink sender = new SendingAmqpLink(session, AmqpUtils.GetLinkSettings(true, entity, SettleMode.SettleOnSend));
-            sender.Open();
+            await sender.OpenAsync();
             for (int i = 0; i < 8; i++)
             {
-                sender.SendMessageNoWait(AmqpMessage.Create(new AmqpValue() { Value = "hello" }), EmptyBinary, NullBinary);
+                await sender.SendMessageAsync(AmqpMessage.Create(new AmqpValue() { Value = "hello" }));
             }
 
             ReceivingAmqpLink rLink = new ReceivingAmqpLink(session, AmqpUtils.GetLinkSettings(false, entity, SettleMode.SettleOnSend, 0));
             rLink.Settings.AutoSendFlow = false;
-            rLink.Open();
+            await rLink.OpenAsync();
 
             for (int i = 0; i < 8; i++)
             {
-                rLink.EndReceiveMessage(rLink.BeginReceiveMessage(TimeSpan.FromSeconds(10), null, null), out AmqpMessage message);
+                AmqpMessage message = await rLink.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
+                Assert.IsNotNull(message);
                 rLink.AcceptMessage(message);
             }
 
@@ -708,7 +709,7 @@ namespace Test.Microsoft.Azure.Amqp
             Assert.AreEqual(0u, rLink.LinkCredit);
             Assert.IsFalse(rLink.Drain);
 
-            connection.Close();
+            await connection.CloseAsync();
         }
 
         [TestMethod]

--- a/test/TestCases/AmqpLinkTests.cs
+++ b/test/TestCases/AmqpLinkTests.cs
@@ -281,7 +281,7 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
-        public void AmqpMessageEmptyTest()
+        public async Task AmqpMessageEmptyTest()
         {
             string queue = "AmqpMessageEmptyTest";
             broker.AddQueue(queue);
@@ -295,18 +295,18 @@ namespace Test.Microsoft.Azure.Amqp
             SendingAmqpLink sLink = new SendingAmqpLink(session, AmqpUtils.GetLinkSettings(true, queue, SettleMode.SettleOnSend));
             sLink.Open();
 
-            AssertExtensions.ThrowsAny<InvalidOperationException>(() =>
+            await AssertExtensions.ThrowsAnyAsync<InvalidOperationException>(async () =>
             {
                 var message = AmqpMessage.Create();
-                sLink.SendMessageAsync(message, AmqpConstants.EmptyBinary, AmqpConstants.NullBinary,
-                    TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+                await sLink.SendMessageAsync(message, AmqpConstants.EmptyBinary, AmqpConstants.NullBinary,
+                    TimeSpan.FromSeconds(30));
             });
 
-            AssertExtensions.ThrowsAny<InvalidOperationException>(() =>
+            await AssertExtensions.ThrowsAnyAsync<InvalidOperationException>(async () =>
             {
                 var message = AmqpMessage.Create(new Data[0]);
-                sLink.SendMessageAsync(message, AmqpConstants.EmptyBinary, AmqpConstants.NullBinary,
-                    TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+                await sLink.SendMessageAsync(message, AmqpConstants.EmptyBinary, AmqpConstants.NullBinary,
+                    TimeSpan.FromSeconds(30));
             });
 
             connection.Close();
@@ -590,7 +590,7 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
-        public void AmqpTransactionTest()
+        public async Task AmqpTransactionTest()
         {
             const int messageCount = 6;
             string queue = "AmqpTransactionCommitTest";
@@ -605,7 +605,7 @@ namespace Test.Microsoft.Azure.Amqp
             Controller txController = new Controller(session, TimeSpan.FromSeconds(10));
             txController.Open();
 
-            ArraySegment<byte> txnId = txController.DeclareAsync().Result;
+            ArraySegment<byte> txnId = await txController.DeclareAsync();
 
             SendingAmqpLink sendLink = new SendingAmqpLink(session, AmqpUtils.GetLinkSettings(true, queue, SettleMode.SettleOnReceive));
             sendLink.Open();
@@ -621,9 +621,9 @@ namespace Test.Microsoft.Azure.Amqp
             }
 
             // rollback txn
-            txController.DischargeAsync(txnId, true).Wait(TimeSpan.FromSeconds(10));
+            await txController.DischargeAsync(txnId, true);
 
-            txnId = txController.DeclareAsync().Result;
+            txnId = await txController.DeclareAsync();
 
             // send message again
             for (int i = 0; i < messageCount; ++i)
@@ -636,13 +636,13 @@ namespace Test.Microsoft.Azure.Amqp
             }
 
             // commit txn
-            txController.DischargeAsync(txnId, false).Wait(TimeSpan.FromSeconds(10));
+            await txController.DischargeAsync(txnId, false);
 
             ReceivingAmqpLink receiveLink = new ReceivingAmqpLink(session, AmqpUtils.GetLinkSettings(false, queue, SettleMode.SettleOnReceive, 20));
             receiveLink.Open();
 
             TransactionalState txnState = new TransactionalState() { Outcome = new Accepted() };
-            txnState.TxnId = txController.DeclareAsync().Result;
+            txnState.TxnId = await txController.DeclareAsync();
 
             // receive message
             AmqpMessage[] messages = new AmqpMessage[messageCount];
@@ -655,9 +655,9 @@ namespace Test.Microsoft.Azure.Amqp
             receiveLink.Session.Flush();    // force dispositions out before discharge frames
 
             // rollback txn
-            txController.DischargeAsync(txnState.TxnId, true).Wait(TimeSpan.FromSeconds(10));
+            await txController.DischargeAsync(txnState.TxnId, true);
 
-            txnState.TxnId = txController.DeclareAsync().Result;
+            txnState.TxnId = await txController.DeclareAsync();
 
             // complete message again
             for (int i = 0; i < messageCount; ++i)
@@ -667,7 +667,7 @@ namespace Test.Microsoft.Azure.Amqp
             receiveLink.Session.Flush();
 
             // commit txn
-            txController.DischargeAsync(txnState.TxnId, false).Wait(TimeSpan.FromSeconds(10));
+            await txController.DischargeAsync(txnState.TxnId, false);
 
             txController.Close(TimeSpan.FromSeconds(5));
             sendLink.Close();
@@ -676,7 +676,7 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
-        public void AmqpLinkDrainTest()
+        public async Task AmqpLinkDrainTest()
         {
             string entity = "AmqpLinkDrainTest";
             broker.AddQueue(entity);
@@ -704,7 +704,7 @@ namespace Test.Microsoft.Azure.Amqp
                 rLink.AcceptMessage(message);
             }
 
-            rLink.DrainAsync(CancellationToken.None).GetAwaiter().GetResult();
+            await rLink.DrainAsync(CancellationToken.None);
             Assert.AreEqual(0u, rLink.LinkCredit);
             Assert.IsFalse(rLink.Drain);
 
@@ -1033,7 +1033,7 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
-        public void AmqpLinkCreditMaxValueTest()
+        public async Task AmqpLinkCreditMaxValueTest()
         {
             string queue = "AmqpLinkCreditMaxValueTest-" + Guid.NewGuid().ToString("N").Substring(6);
             broker.AddQueue(queue);
@@ -1060,7 +1060,7 @@ namespace Test.Microsoft.Azure.Amqp
             bool hasMessage = rLink.EndReceiveMessage(rLink.BeginReceiveMessage(TimeSpan.FromSeconds(20), null, null), out message);
             Assert.IsTrue(hasMessage);
             Assert.IsNotNull(message);
-            outcome = rLink.DisposeMessageAsync(message.DeliveryTag, new Accepted(), false, TimeSpan.FromSeconds(15)).Result;
+            outcome = await rLink.DisposeMessageAsync(message.DeliveryTag, new Accepted(), false, TimeSpan.FromSeconds(15));
             Assert.AreEqual(Accepted.Code, outcome.DescriptorCode);
 
             connection.Close();

--- a/test/TestCases/AmqpLinkTests.cs
+++ b/test/TestCases/AmqpLinkTests.cs
@@ -682,26 +682,25 @@ namespace Test.Microsoft.Azure.Amqp
             broker.AddQueue(entity);
 
             AmqpConnection connection = AmqpUtils.CreateConnection(addressUri, null, false, null, 65536);
-            await connection.OpenAsync();
+            connection.Open();
 
             AmqpSession session = connection.CreateSession(new AmqpSessionSettings());
-            await session.OpenAsync();
+            session.Open();
 
             SendingAmqpLink sender = new SendingAmqpLink(session, AmqpUtils.GetLinkSettings(true, entity, SettleMode.SettleOnSend));
-            await sender.OpenAsync();
+            sender.Open();
             for (int i = 0; i < 8; i++)
             {
-                await sender.SendMessageAsync(AmqpMessage.Create(new AmqpValue() { Value = "hello" }));
+                sender.SendMessageNoWait(AmqpMessage.Create(new AmqpValue() { Value = "hello" }), EmptyBinary, NullBinary);
             }
 
             ReceivingAmqpLink rLink = new ReceivingAmqpLink(session, AmqpUtils.GetLinkSettings(false, entity, SettleMode.SettleOnSend, 0));
             rLink.Settings.AutoSendFlow = false;
-            await rLink.OpenAsync();
+            rLink.Open();
 
             for (int i = 0; i < 8; i++)
             {
-                AmqpMessage message = await rLink.ReceiveMessageAsync(TimeSpan.FromSeconds(10));
-                Assert.IsNotNull(message);
+                rLink.EndReceiveMessage(rLink.BeginReceiveMessage(TimeSpan.FromSeconds(10), null, null), out AmqpMessage message);
                 rLink.AcceptMessage(message);
             }
 

--- a/test/TestCases/AmqpWebSocketTests.cs
+++ b/test/TestCases/AmqpWebSocketTests.cs
@@ -31,10 +31,10 @@ namespace Test.Microsoft.Azure.Amqp
                 TestAmqpBrokerFixture.WsAddress.OriginalString);
 
             AmqpSession session = connection.CreateSession(new AmqpSessionSettings());
-            session.Open();
+            await session.OpenAsync();
 
             SendingAmqpLink sLink = new SendingAmqpLink(session, AmqpUtils.GetLinkSettings(true, queue, SettleMode.SettleOnSend));
-            sLink.Open();
+            await sLink.OpenAsync();
 
             int messageCount = 1800;
             for (int i = 0; i < messageCount; i++)
@@ -43,10 +43,10 @@ namespace Test.Microsoft.Azure.Amqp
                 await sLink.SendMessageAsync(message);
             }
 
-            sLink.Close();
+            await sLink.CloseAsync();
 
             ReceivingAmqpLink rLink = new ReceivingAmqpLink(session, AmqpUtils.GetLinkSettings(false, queue, SettleMode.SettleOnReceive, 100));
-            rLink.Open();
+            await rLink.OpenAsync();
 
             for (int i = 0; i < messageCount; i++)
             {
@@ -57,9 +57,9 @@ namespace Test.Microsoft.Azure.Amqp
                 message2.Dispose();
             }
 
-            rLink.Close();
+            await rLink.CloseAsync();
 
-            connection.Close();
+            await connection.CloseAsync();
         }
     }
 }

--- a/test/TestCases/AmqpWebSocketTests.cs
+++ b/test/TestCases/AmqpWebSocketTests.cs
@@ -4,6 +4,7 @@
 namespace Test.Microsoft.Azure.Amqp
 {
     using System;
+    using System.Threading.Tasks;
     using global::Microsoft.Azure.Amqp;
     using global::Microsoft.Azure.Amqp.Framing;
     using global::Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -21,13 +22,13 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
-        public void AmqpWebSocketTransportTest()
+        public async Task AmqpWebSocketTransportTest()
         {
             string queue = "AmqpWebSocketTransportTest";
             broker.AddQueue(queue);
 
-            AmqpConnection connection = AmqpConnection.Factory.OpenConnectionAsync(
-                TestAmqpBrokerFixture.WsAddress.OriginalString).GetAwaiter().GetResult();
+            AmqpConnection connection = await AmqpConnection.Factory.OpenConnectionAsync(
+                TestAmqpBrokerFixture.WsAddress.OriginalString);
 
             AmqpSession session = connection.CreateSession(new AmqpSessionSettings());
             session.Open();
@@ -39,7 +40,7 @@ namespace Test.Microsoft.Azure.Amqp
             for (int i = 0; i < messageCount; i++)
             {
                 AmqpMessage message = AmqpMessage.Create(new AmqpValue() { Value = "message" + i });
-                sLink.SendMessageAsync(message).Wait();
+                await sLink.SendMessageAsync(message);
             }
 
             sLink.Close();
@@ -49,7 +50,7 @@ namespace Test.Microsoft.Azure.Amqp
 
             for (int i = 0; i < messageCount; i++)
             {
-                AmqpMessage message2 = rLink.ReceiveMessageAsync(TimeSpan.FromSeconds(60)).GetAwaiter().GetResult();
+                AmqpMessage message2 = await rLink.ReceiveMessageAsync(TimeSpan.FromSeconds(60));
                 Assert.IsNotNull(message2);
 
                 rLink.AcceptMessage(message2);

--- a/test/TestCases/UtilityTests.cs
+++ b/test/TestCases/UtilityTests.cs
@@ -382,13 +382,13 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
-        public void FaultTolerantAmqpObjectShouldInvokeCloseMethodOnClose()
+        public async Task FaultTolerantAmqpObjectShouldInvokeCloseMethodOnClose()
         {
             bool isCloseHandlerInvoked = false;
             var faultTolerantObject = new FaultTolerantAmqpObject<TestAmqpObject>(
                 (CancellationToken ct) => Task.FromResult(new TestAmqpObject("string")),
                 amqpObject => { isCloseHandlerInvoked = true; });
-            var testAmqpObject = faultTolerantObject.GetOrCreateAsync(CancellationToken.None).Result;
+            var testAmqpObject = await faultTolerantObject.GetOrCreateAsync(CancellationToken.None);
             testAmqpObject.Close();
             Assert.IsTrue(isCloseHandlerInvoked);
         }


### PR DESCRIPTION
NET 8 is out of support, so this moves the SDK, test targets, and CI forward.

The global.json was pinned to 8.0.400 to stop newer SDKs from auto-importing iOS/MAUI workloads (see e4e37f8). Since we are now targeting .NET 10 explicitly, that concern is no longer relevant.

Changes:
- global.json: SDK version 8.0.400 to 10.0.100
- Test projects: target frameworks net462;net8.0 to net48;net10.0
- CI runner: windows-2022 to windows-2025
- CI: dotnet-version 8.0.x to 10.0.x

The library itself stays on netstandard2.0. That is the package's compatibility surface and does not need to change.