### PR TITLE
Avoid per-batch list allocation in AsyncWriter

### DIFF
--- a/src/AsyncIO.cs
+++ b/src/AsyncIO.cs
@@ -571,6 +571,7 @@ namespace Microsoft.Azure.Amqp
         public class AsyncWriter
         {
             const int MaxBatchSize = 32 * 1024;
+            const int MaxRetainedBatchCapacity = 64;
             static readonly Action<TransportAsyncCallbackArgs> writeCompleteCallback = WriteCompleteCallback;
             readonly TransportBase transport;
             readonly int writeQueueFullLimit;
@@ -807,7 +808,20 @@ namespace Microsoft.Azure.Amqp
                 }
 
                 args.Reset();
-                this.batchBufferList?.Clear();
+
+                // Reuse the batch buffer list across writes, but discard it when a burst grew
+                // the backing array beyond the retained capacity so that the oversized array
+                // becomes eligible for garbage collection instead of being pinned for the
+                // lifetime of the connection.
+                if (this.batchBufferList?.Capacity > MaxRetainedBatchCapacity)
+                {
+                    this.batchBufferList = null;
+                }
+                else
+                {
+                    this.batchBufferList?.Clear();
+                }
+
                 return shouldContinue;
             }
         }

--- a/src/AsyncIO.cs
+++ b/src/AsyncIO.cs
@@ -578,6 +578,7 @@ namespace Microsoft.Azure.Amqp
             readonly TransportAsyncCallbackArgs writeAsyncEventArgs;
             readonly Queue<ByteBuffer> bufferQueue;
             readonly IIoHandler parent;
+            List<ByteBuffer> batchBufferList;
             long bufferQueueSize;
             bool writing;
             bool closed;
@@ -774,17 +775,17 @@ namespace Microsoft.Azure.Amqp
                         }
                         else
                         {
-                            var buffers = new List<ByteBuffer>(Math.Min(count, 64));
+                            this.batchBufferList ??= new List<ByteBuffer>(Math.Min(count, 64));
                             int size = 0;
                             for (int i = 0; i < count && size < MaxBatchSize; i++)
                             {
                                 ByteBuffer buffer = this.bufferQueue.Dequeue();
-                                buffers.Add(buffer);
+                                this.batchBufferList.Add(buffer);
                                 size += buffer.Length;
                             }
 
                             this.OnBufferDequeued(size);
-                            this.writeAsyncEventArgs.SetBuffer(buffers);
+                            this.writeAsyncEventArgs.SetBuffer(this.batchBufferList);
                         }
                     }
                 }
@@ -806,6 +807,7 @@ namespace Microsoft.Azure.Amqp
                 }
 
                 args.Reset();
+                this.batchBufferList?.Clear();
                 return shouldContinue;
             }
         }

--- a/test/Test.Microsoft.Amqp/Test.Microsoft.Amqp.csproj
+++ b/test/Test.Microsoft.Amqp/Test.Microsoft.Amqp.csproj
@@ -24,6 +24,7 @@
     <Compile Include="..\Common\TestRuntimeProvider.cs" Link="Common\TestRuntimeProvider.cs" />
     <Compile Include="..\TestAmqpBroker\Node.cs" Link="Node.cs" />
     <Compile Include="..\TestAmqpBroker\TestAmqpBroker.cs" Link="TestAmqpBroker.cs" />
+    <Compile Include="..\TestCases\AsyncIOTests.cs" Link="TestCases\AsyncIOTests.cs" />
     <Compile Include="..\TestCases\AmqpCodecTests.cs" Link="TestCases\AmqpCodecTests.cs" />
     <Compile Include="..\TestCases\AmqpConnectionListenerTests.cs" Link="TestCases\AmqpConnectionListenerTests.cs" />
     <Compile Include="..\TestCases\AmqpConnectionTests.cs" Link="TestCases\AmqpConnectionTests.cs" />

--- a/test/TestCases/AsyncIOTests.cs
+++ b/test/TestCases/AsyncIOTests.cs
@@ -1,0 +1,202 @@
+namespace Test.Microsoft.Azure.Amqp
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using global::Microsoft.Azure.Amqp;
+    using global::Microsoft.Azure.Amqp.Transport;
+    using global::Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class AsyncIOTests
+    {
+        [TestMethod]
+        public void AsyncWriterReusesBatchBufferListAfterAsyncWrites()
+        {
+            var transport = new TestTransport();
+            var writer = new AsyncIO.AsyncWriter(transport, int.MaxValue, int.MaxValue, new TestIoHandler());
+
+            writer.WriteBuffer(CreateBuffer(1));
+            writer.WriteBuffer(CreateBuffer(2));
+            writer.WriteBuffer(CreateBuffer(3));
+
+            transport.CompleteWrite();
+            IList<ByteBuffer> firstBatch = transport.PendingWrite.ByteBufferList;
+            Assert.AreEqual(2, firstBatch.Count);
+            Assert.AreEqual(2, firstBatch[0].Length);
+            Assert.AreEqual(3, firstBatch[1].Length);
+
+            writer.WriteBuffer(CreateBuffer(4));
+            writer.WriteBuffer(CreateBuffer(5));
+
+            transport.CompleteWrite();
+            IList<ByteBuffer> secondBatch = transport.PendingWrite.ByteBufferList;
+            Assert.AreSame(firstBatch, secondBatch);
+            Assert.AreEqual(2, secondBatch.Count);
+            Assert.AreEqual(4, secondBatch[0].Length);
+            Assert.AreEqual(5, secondBatch[1].Length);
+
+            transport.CompleteWrite();
+            Assert.AreEqual(0, secondBatch.Count);
+        }
+
+        [TestMethod]
+        public void AsyncWriterReusesBatchBufferListAfterSynchronousWrites()
+        {
+            var transport = new TestTransport() { CompletesSynchronously = true };
+            AsyncIO.AsyncWriter writer = null;
+            transport.OnWrite = writeCount =>
+            {
+                if (writeCount == 1)
+                {
+                    writer.WriteBuffer(CreateBuffer(2));
+                    writer.WriteBuffer(CreateBuffer(3));
+                }
+                else if (writeCount == 2)
+                {
+                    writer.WriteBuffer(CreateBuffer(4));
+                    writer.WriteBuffer(CreateBuffer(5));
+                }
+            };
+
+            writer = new AsyncIO.AsyncWriter(transport, int.MaxValue, int.MaxValue, new TestIoHandler());
+            writer.WriteBuffer(CreateBuffer(1));
+
+            Assert.AreEqual(2, transport.BatchBufferLists.Count);
+            Assert.AreSame(transport.BatchBufferLists[0], transport.BatchBufferLists[1]);
+            Assert.AreEqual(0, transport.BatchBufferLists[0].Count);
+        }
+
+        [TestMethod]
+        public void AsyncWriterClearsBatchBufferListWhenTransportThrows()
+        {
+            var transport = new TestTransport() { ThrowOnWriteNumber = 2 };
+            var ioHandler = new TestIoHandler();
+            var writer = new AsyncIO.AsyncWriter(transport, int.MaxValue, int.MaxValue, ioHandler);
+
+            writer.WriteBuffer(CreateBuffer(1));
+            writer.WriteBuffer(CreateBuffer(2));
+            writer.WriteBuffer(CreateBuffer(3));
+
+            transport.CompleteWrite();
+
+            Assert.AreSame(transport.WriteException, ioHandler.Exception);
+            Assert.AreEqual(1, transport.BatchBufferLists.Count);
+            Assert.AreEqual(0, transport.BatchBufferLists[0].Count);
+        }
+
+        static ByteBuffer CreateBuffer(int size)
+        {
+            return new ByteBuffer(new byte[size], 0, size);
+        }
+
+        sealed class TestTransport : TransportBase
+        {
+            int writeCount;
+
+            public TestTransport()
+                : base("test")
+            {
+                this.BatchBufferLists = new List<IList<ByteBuffer>>();
+                this.WriteException = new InvalidOperationException("write failed");
+            }
+
+            internal override EndPoint Local => null;
+
+            internal override EndPoint Remote => null;
+
+            public override string LocalEndPoint => null;
+
+            public override string RemoteEndPoint => null;
+
+            public bool CompletesSynchronously { get; set; }
+
+            public int ThrowOnWriteNumber { get; set; }
+
+            public Exception WriteException { get; }
+
+            public Action<int> OnWrite { get; set; }
+
+            public List<IList<ByteBuffer>> BatchBufferLists { get; }
+
+            public TransportAsyncCallbackArgs PendingWrite { get; private set; }
+
+            public override void SetMonitor(ITransportMonitor usageMeter)
+            {
+            }
+
+            public override bool WriteAsync(TransportAsyncCallbackArgs args)
+            {
+                this.writeCount++;
+                if (args.ByteBufferList != null)
+                {
+                    this.BatchBufferLists.Add(args.ByteBufferList);
+                }
+
+                this.OnWrite?.Invoke(this.writeCount);
+                if (this.ThrowOnWriteNumber == this.writeCount)
+                {
+                    throw this.WriteException;
+                }
+
+                if (this.CompletesSynchronously)
+                {
+                    args.BytesTransfered = args.Count;
+                    return false;
+                }
+
+                Assert.IsNull(this.PendingWrite);
+                this.PendingWrite = args;
+                return true;
+            }
+
+            public override bool ReadAsync(TransportAsyncCallbackArgs args)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void CompleteWrite()
+            {
+                TransportAsyncCallbackArgs args = this.PendingWrite;
+                Assert.IsNotNull(args);
+                this.PendingWrite = null;
+                args.BytesTransfered = args.Count;
+                args.CompletedSynchronously = false;
+                args.CompletedCallback(args);
+            }
+
+            protected override bool CloseInternal()
+            {
+                return true;
+            }
+
+            protected override void AbortInternal()
+            {
+            }
+        }
+
+        sealed class TestIoHandler : IIoHandler
+        {
+            public Exception Exception { get; private set; }
+
+            public ByteBuffer CreateBuffer(int frameSize)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void OnReceiveBuffer(ByteBuffer buffer)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void OnIoFault(Exception exception)
+            {
+                this.Exception = exception;
+            }
+
+            public void OnIoEvent(IoEvent ioEvent, long queueSize)
+            {
+            }
+        }
+    }
+}

--- a/test/TestCases/AsyncIOTests.cs
+++ b/test/TestCases/AsyncIOTests.cs
@@ -85,6 +85,30 @@ namespace Test.Microsoft.Azure.Amqp
             Assert.AreEqual(0, transport.BatchBufferLists[0].Count);
         }
 
+        [TestMethod]
+        public void AsyncWriterDiscardsBatchBufferListAfterLargeBurst()
+        {
+            var transport = new TestTransport();
+            var writer = new AsyncIO.AsyncWriter(transport, int.MaxValue, int.MaxValue, new TestIoHandler());
+
+            writer.WriteBuffer(CreateBuffer(1));
+            for (int i = 0; i < 100; i++)
+            {
+                writer.WriteBuffer(CreateBuffer(1));
+            }
+
+            transport.CompleteWrite();
+            IList<ByteBuffer> largeBatch = transport.BatchBufferLists[0];
+            Assert.AreEqual(100, largeBatch.Count);
+
+            writer.WriteBuffer(CreateBuffer(2));
+            writer.WriteBuffer(CreateBuffer(3));
+
+            transport.CompleteWrite();
+            Assert.AreEqual(2, transport.BatchBufferLists.Count);
+            Assert.AreNotSame(largeBatch, transport.BatchBufferLists[1]);
+        }
+
         static ByteBuffer CreateBuffer(int size)
         {
             return new ByteBuffer(new byte[size], 0, size);


### PR DESCRIPTION
`AsyncWriter.ContinueWrite()` creates a new `List<ByteBuffer>` for every multi-buffer batch. This changes the writer to create that list lazily and reuse it across writes.

The list is cleared after `TransportAsyncCallbackArgs.Reset()` disposes the completed batch. Buffer ownership remains unchanged, and the single-write-in-flight model ensures the list is not modified while a transport write is pending.

Tests cover asynchronous completion, synchronous completion, and exceptions thrown by the transport.

This is intentionally separate from #308, which reuses the `TcpTransport` scatter/gather adapter. The two changes can be merged independently and in either order.
