### PR TITLE
Fix decimal128 encoding and add canonical wire-byte tests

### DIFF
--- a/src/Encoding/DecimalEncoding.cs
+++ b/src/Encoding/DecimalEncoding.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Amqp.Encoding
         const int Decimal32Bias = 101;
         const int Decimal64Bias = 398;
         const int Decimal128Bias = 6176;
+        static readonly bool decimalDataLayoutCompatible = IsDecimalDataLayoutCompatible();
 
         public DecimalEncoding()
             : base(FormatCode.Decimal128)
@@ -102,6 +103,24 @@ namespace Microsoft.Azure.Amqp.Encoding
             public uint Mid;
         }
 
+        static bool IsDecimalDataLayoutCompatible()
+        {
+            decimal value = new decimal(
+                unchecked((int)0x89ABCDEF),
+                0x01234567,
+                0x76543210,
+                true,
+                28);
+
+            int[] bits = decimal.GetBits(value);
+            var data = new DecimalData { Value = value };
+
+            return data.Low == unchecked((uint)bits[0])
+                && data.Mid == unchecked((uint)bits[1])
+                && data.High == unchecked((uint)bits[2])
+                && data.Flags == unchecked((uint)bits[3]);
+        }
+
         static void GetDecimalBits(decimal value, Span<uint> destination)
         {
             if (destination.Length < 4)
@@ -109,7 +128,7 @@ namespace Microsoft.Azure.Amqp.Encoding
                 throw new ArgumentException("Destination is too short.", nameof(destination));
             }
 
-            if (BitConverter.IsLittleEndian)
+            if (decimalDataLayoutCompatible)
             {
                 var data = new DecimalData { Value = value };
                 destination[0] = data.Low;

--- a/src/Encoding/DecimalEncoding.cs
+++ b/src/Encoding/DecimalEncoding.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.Azure.Amqp.Encoding
 {
     using System;
+    using System.Buffers.Binary;
+    using System.Runtime.InteropServices;
 
     /// <summary>
     /// Decoding from AMQP decimal to C# decimal can lose precision and
@@ -81,40 +83,76 @@ namespace Microsoft.Azure.Amqp.Encoding
             return DecodeValue(buffer, formatCode);
         }
 
-        static unsafe void EncodeValue(decimal value, ByteBuffer buffer)
+        [StructLayout(LayoutKind.Explicit)]
+        struct DecimalData
         {
-            int[] bits = Decimal.GetBits(value);
-            int lowSignificant = bits[0];
-            int middleSignificant = bits[1];
-            int highSignificant = bits[2];
-            int signAndExponent = bits[3];
+            [FieldOffset(0)]
+            public decimal Value;
+
+            [FieldOffset(0)]
+            public uint Flags;
+
+            [FieldOffset(4)]
+            public uint High;
+
+            [FieldOffset(8)]
+            public uint Low;
+
+            [FieldOffset(12)]
+            public uint Mid;
+        }
+
+        static void GetDecimalBits(decimal value, Span<uint> destination)
+        {
+            if (destination.Length < 4)
+            {
+                throw new ArgumentException("Destination is too short.", nameof(destination));
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                var data = new DecimalData { Value = value };
+                destination[0] = data.Low;
+                destination[1] = data.Mid;
+                destination[2] = data.High;
+                destination[3] = data.Flags;
+                return;
+            }
+
+            // Portable fallback for big-endian or otherwise unusual runtimes.
+            // It allocates, but correctness takes priority on this uncommon path.
+            int[] bits = decimal.GetBits(value);
+            destination[0] = (uint)bits[0];
+            destination[1] = (uint)bits[1];
+            destination[2] = (uint)bits[2];
+            destination[3] = (uint)bits[3];
+        }
+
+        static void EncodeValue(decimal value, ByteBuffer buffer)
+        {
+            Span<uint> bits = stackalloc uint[4];
+            GetDecimalBits(value, bits);
+
+            uint low = bits[0];
+            uint middle = bits[1];
+            uint high = bits[2];
+            uint flags = bits[3];
+
+            int scale = (byte)(flags >> 16);
+            int exponent = Decimal128Bias - scale;
 
             Span<byte> bytes = stackalloc byte[FixedWidth.Decimal128];
-            byte* p = (byte*)&signAndExponent;
-            int exponent = Decimal128Bias - p[2];
-            bytes[0] = p[3];    // sign
-            bytes[0] |= (byte)(exponent >> 9);  // 7 bits in msb
-            bytes[1] = (byte)((exponent & 0x7F) << 1);  // 7 bits in 2nd msb
+
+            // decimal128 finite-value layout:
+            // sign + upper 7 exponent bits, lower 7 exponent bits, coefficient.
+            bytes[0] = (byte)((flags >> 24) | (uint)(exponent >> 7));
+            bytes[1] = (byte)((exponent & 0x7F) << 1);
             bytes[2] = 0;
             bytes[3] = 0;
 
-            p = (byte*)&highSignificant;
-            bytes[4] = p[3];
-            bytes[5] = p[2];
-            bytes[6] = p[1];
-            bytes[7] = p[0];
-
-            p = (byte*)&middleSignificant;
-            bytes[8] = p[3];
-            bytes[9] = p[2];
-            bytes[10] = p[1];
-            bytes[11] = p[0];
-
-            p = (byte*)&lowSignificant;
-            bytes[12] = p[3];
-            bytes[13] = p[2];
-            bytes[14] = p[1];
-            bytes[15] = p[0];
+            BinaryPrimitives.WriteUInt32BigEndian(bytes.Slice(4, 4), high);
+            BinaryPrimitives.WriteUInt32BigEndian(bytes.Slice(8, 4), middle);
+            BinaryPrimitives.WriteUInt32BigEndian(bytes.Slice(12, 4), low);
 
             AmqpBitConverter.WriteBytes(buffer, bytes, 0, bytes.Length);
         }

--- a/test/TestCases/AmqpCodecTests.cs
+++ b/test/TestCases/AmqpCodecTests.cs
@@ -1462,6 +1462,184 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [TestMethod]
+        public void AmqpCodecDecimal128CanonicalWireBytesTest()
+        {
+            // Canonical decimal128 wire bytes.
+            // Each test encodes a C# decimal and compares all 17 bytes
+            // (format code 0x94 + 16 payload bytes) against hard-coded expected values.
+
+            void AssertEncoded(decimal value, byte[] expectedPayload)
+            {
+                byte[] expected = new byte[1 + expectedPayload.Length];
+                expected[0] = 0x94;
+                Array.Copy(expectedPayload, 0, expected, 1, expectedPayload.Length);
+
+                var buffer = new ByteBuffer(new byte[FixedWidth.Decimal128Encoded]);
+                AmqpCodec.EncodeDecimal(value, buffer);
+
+                EnsureEqual(expected, 0, expected.Length, buffer.Buffer, buffer.Offset, buffer.Length);
+            }
+
+            // 0m
+            AssertEncoded(0m, new byte[]
+                { 0x30, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+
+            // 1m
+            AssertEncoded(1m, new byte[]
+                { 0x30, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 });
+
+            // -1m
+            AssertEncoded(-1m, new byte[]
+                { 0xB0, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 });
+
+            // 1.00m
+            AssertEncoded(1.00m, new byte[]
+                { 0x30, 0x3C, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64 });
+
+            // decimal.MaxValue
+            AssertEncoded(decimal.MaxValue, new byte[]
+                { 0x30, 0x40, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF });
+
+            // decimal.MinValue
+            AssertEncoded(decimal.MinValue, new byte[]
+                { 0xB0, 0x40, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF });
+
+            // 0.0000000000000000000000000001m (smallest positive with scale 28)
+            AssertEncoded(0.0000000000000000000000000001m, new byte[]
+                { 0x30, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 });
+
+            // Negative zero
+            decimal negativeZero = new decimal(0, 0, 0, true, 0);
+            AssertEncoded(negativeZero, new byte[]
+                { 0xB0, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
+        }
+
+        [TestMethod]
+        public void AmqpCodecDecimal128PreservesScaleAndSignTest()
+        {
+            // Values that are numerically equal but have different representations
+            // must produce different wire bytes.
+
+            byte[] EncodeToBytes(decimal value)
+            {
+                var buffer = new ByteBuffer(new byte[FixedWidth.Decimal128Encoded]);
+                AmqpCodec.EncodeDecimal(value, buffer);
+                byte[] result = new byte[buffer.Length];
+                Array.Copy(buffer.Buffer, buffer.Offset, result, 0, buffer.Length);
+                return result;
+            }
+
+            byte[] one = EncodeToBytes(1m);
+            byte[] onePointZero = EncodeToBytes(1.0m);
+            byte[] onePointZeroZero = EncodeToBytes(1.00m);
+
+            // All three must produce different wire representations
+            Assert.AreNotEqual(one.Length, 0);
+            bool oneEqOneZero = true;
+            bool oneEqOneZeroZero = true;
+            bool oneZeroEqOneZeroZero = true;
+            for (int i = 0; i < one.Length; i++)
+            {
+                if (one[i] != onePointZero[i]) oneEqOneZero = false;
+                if (one[i] != onePointZeroZero[i]) oneEqOneZeroZero = false;
+                if (onePointZero[i] != onePointZeroZero[i]) oneZeroEqOneZeroZero = false;
+            }
+            Assert.IsFalse(oneEqOneZero, "1m and 1.0m must differ");
+            Assert.IsFalse(oneEqOneZeroZero, "1m and 1.00m must differ");
+            Assert.IsFalse(oneZeroEqOneZeroZero, "1.0m and 1.00m must differ");
+
+            // Verify sign and scale using decimal.GetBits as reference
+            int[] bits1 = decimal.GetBits(1m);
+            int[] bits10 = decimal.GetBits(1.0m);
+            int[] bits100 = decimal.GetBits(1.00m);
+
+            // All positive (sign bit in bits[3] bit 31)
+            Assert.IsTrue((bits1[3] & unchecked((int)0x80000000)) == 0);
+            Assert.IsTrue((bits10[3] & unchecked((int)0x80000000)) == 0);
+            Assert.IsTrue((bits100[3] & unchecked((int)0x80000000)) == 0);
+
+            // Scales differ: 0, 1, 2
+            Assert.AreEqual(0, (bits1[3] >> 16) & 0xFF);
+            Assert.AreEqual(1, (bits10[3] >> 16) & 0xFF);
+            Assert.AreEqual(2, (bits100[3] >> 16) & 0xFF);
+        }
+
+        [TestMethod]
+        public void AmqpCodecDecimal128RoundTripTest()
+        {
+            void AssertRoundTrip(decimal value)
+            {
+                var buffer = new ByteBuffer(new byte[FixedWidth.Decimal128Encoded]);
+                AmqpCodec.EncodeDecimal(value, buffer);
+                decimal decoded = AmqpCodec.DecodeDecimal(buffer).Value;
+                Assert.AreEqual(value, decoded);
+            }
+
+            // Zero and negative zero
+            AssertRoundTrip(0m);
+            AssertRoundTrip(new decimal(0, 0, 0, true, 0));
+
+            // Positive and negative values
+            AssertRoundTrip(1m);
+            AssertRoundTrip(-1m);
+            AssertRoundTrip(42m);
+            AssertRoundTrip(-42m);
+
+            // Various scales
+            AssertRoundTrip(1.0m);
+            AssertRoundTrip(1.00m);
+            AssertRoundTrip(3.14159m);
+            AssertRoundTrip(0.0000000000000000000000000001m);
+
+            // Min/Max
+            AssertRoundTrip(decimal.MinValue);
+            AssertRoundTrip(decimal.MaxValue);
+
+            // Values with all three coefficient words non-zero
+            AssertRoundTrip(1234567890123456789012345678m);
+            AssertRoundTrip(-1234567890123456789012345678m);
+        }
+
+        [TestMethod]
+        public void AmqpCodecDecimal128ArrayRoundTripTest()
+        {
+            decimal[] values = new decimal[]
+            {
+                decimal.MinValue,
+                -234934.092348m,
+                0m,
+                new decimal(0, 0, 0, true, 0), // negative zero
+                38743947394.2349324m,
+                decimal.MaxValue
+            };
+
+            int size = AmqpCodec.GetArrayEncodeSize(values);
+            ByteBuffer buffer = new ByteBuffer(size, true);
+            AmqpCodec.EncodeArray(values, buffer);
+
+            decimal[] decoded = AmqpCodec.DecodeArray<decimal>(buffer);
+            Assert.AreEqual(values.Length, decoded.Length);
+            for (int i = 0; i < values.Length; i++)
+            {
+                Assert.AreEqual(values[i], decoded[i]);
+            }
+        }
+
+        [TestMethod]
+        public void AmqpCodecDecimal128ExistingFixturesTest()
+        {
+            // Existing decode fixtures must continue to work.
+            decimal? dec32 = AmqpCodec.DecodeDecimal(new ByteBuffer(new ArraySegment<byte>(decimal32ValueBin)));
+            Assert.IsTrue(dec32.Value == decimal32Value, "Decimal32 value is not equal");
+
+            decimal? dec64 = AmqpCodec.DecodeDecimal(new ByteBuffer(new ArraySegment<byte>(decimal64ValueBin)));
+            Assert.IsTrue(dec64.Value == decimal64Value, "Decimal64 value is not equal");
+
+            decimal? dec128 = AmqpCodec.DecodeDecimal(new ByteBuffer(new ArraySegment<byte>(decimal128ValueBin)));
+            Assert.IsTrue(dec128.Value == decimal128Value, "Decimal128 value is not equal");
+        }
+
+        [TestMethod]
         public void AmqpCodecNestedDescribedMapDepthTest()
         {
             int depth = 100;


### PR DESCRIPTION
The decimal128 encoder had three issues the existing tests didn't catch.

The most visible one is the exponent shift. `EncodeValue` used `exponent >> 9` where it needed `>> 7`. For `decimal.MaxValue` that turns the first payload byte from `0x30` into `0x0C`. Round-trip tests hid it because the decoder casts an out-of-range scale to `byte`, which wraps the value back to the original. I caught it by encoding against hard-coded expected bytes derived from the IEEE 754 decimal128 layout instead of round-tripping through this library. The `decimal.MaxValue` row also matches the existing `decimal128ValueBin` decode fixture, so it isn't just self-consistent with the encoder.

AMQP defines decimal128 as IEEE 754-2008 using Binary Integer Decimal encoding:
https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#type-decimal128

The other two issues were endianness and allocation. The encoder read scale and sign from fixed byte offsets of an `int` and reversed coefficient words by hand with pointer arithmetic, which only works on little-endian runtimes. It also allocated a four-element `int[]` via `Decimal.GetBits` on every encode, including every element of a decimal array.

This change rewrites `EncodeValue` to:

- extract scale and sign with numeric shifts on the flags word
- write coefficient words with `BinaryPrimitives.WriteUInt32BigEndian`
- use an explicit-layout decimal overlay with a stack-allocated component span
- verify the overlay once against the public `decimal.GetBits` representation before enabling the allocation-free path
- fall back to `decimal.GetBits` on any runtime whose decimal layout does not match

The layout probe incurs one process-wide four-element array allocation. Encoding is allocation-free after initialization on runtimes with the expected layout, while remaining compatible with any .NET Standard implementation.

This intentionally changes decimal128 bytes emitted by previous versions from their malformed representation to the standards-compliant BID representation. The decoding code is unchanged and continues to accept the historical representation produced by this encoder for C# decimal scales.

I left the decimal32, decimal64, and decimal128 decoders alone.

I pushed the tests first on purpose. CI went red on `AmqpCodecDecimal128CanonicalWireBytesTest` with `48 != 12`, which is the `0x30` versus `0x0C` byte. The second commit turns it green. I wanted the red run as evidence that the tests actually exercise the defect instead of passing because both sides agree on the same wrong bytes.

The library still targets `netstandard2.0`. I didn't use the span-based `decimal.GetBits` overload because it isn't available on that target.