### PR TITLE
build(broker): add CFSClean NuGet restore path

### DIFF
--- a/nuget.cfsclean.config
+++ b/nuget.cfsclean.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  NuGet configuration for CFSClean builds.
+
+  Use this file explicitly as the dotnet restore config file. The clear entries
+  prevent machine-wide and user-level sources from adding direct public
+  endpoints to the restore.
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="azure-sdk-for-net" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -5,7 +5,7 @@
     <add key="automatic" value="True" />
   </packageRestore>
   <packageSources>
-    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,14 @@ Azure SDK pipelines that run on CFSClean agents must restore `TestAmqpBroker` wi
 
 Downstream repositories clone this repository at a pinned commit and follow this section. Keep the clone unchanged and pass `--configfile` on the restore. A consumer can override the pinned commit with the `TEST_BROKER_COMMIT` environment variable.
 
+#### Package source names
+
+The root `nuget.config` names the NuGet.org source `nuget.org`. Keep that name.
+
+A restricted agent turns off NuGet.org through a `disabledPackageSources` entry, and that entry matches a source by name and not by URL. A source that repeats the same URL under a different name is therefore a different source, and the agent policy does not turn it off. This file used the name `NuGet official package source` until [#318](https://github.com/Azure/azure-amqp/pull/318), so a restore on a restricted agent reached NuGet.org directly and the agent policy had no effect.
+
+Do not rename this source, and do not add a second source that repeats the NuGet.org URL.
+
 #### .NET SDK requirement
 
 `global.json` pins the SDK to version `10.0.100`, with `rollForward: latestFeature` and `allowPrerelease: false`. This policy accepts any released `10.0.x` SDK at version `10.0.100` or later. It does not roll forward to a different major or minor version. It does not accept a prerelease SDK. The agent must have a released 10.0 SDK.

--- a/readme.md
+++ b/readme.md
@@ -20,15 +20,51 @@ dotnet build -p:Version=3.0.0 src\Microsoft.Azure.Amqp.csproj
 
 ### CFSClean test broker build
 
-Azure SDK pipelines running on CFSClean agents must restore `TestAmqpBroker` with the checked-in `nuget.cfsclean.config`. The config clears inherited package sources and uses the public `azure-sdk-for-net` Azure Artifacts feed, which has a NuGet.org upstream.
+Azure SDK pipelines that run on CFSClean agents must restore `TestAmqpBroker` with the checked-in `nuget.cfsclean.config`. The config clears inherited package sources. It uses the public `azure-sdk-for-net` Azure Artifacts feed, which has a NuGet.org upstream.
 
-Azure DevOps pipelines must run `NuGetAuthenticate@1` before the restore. Authentication allows the feed to serve upstream cache misses while the agent remains isolated from NuGet.org.
+Downstream repositories clone this repository at a pinned commit and follow this section. Keep the clone unchanged and pass `--configfile` on the restore. A consumer can override the pinned commit with the `TEST_BROKER_COMMIT` environment variable.
 
-Run these commands from the root of a pinned `azure-amqp` clone:
+#### .NET SDK requirement
 
-```powershell
-dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile .\nuget.cfsclean.config
-dotnet build .\test\TestAmqpBroker\TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
+`global.json` pins the SDK to version `10.0.100`, with `rollForward: latestFeature` and `allowPrerelease: false`. This policy accepts any released `10.0.x` SDK at version `10.0.100` or later. It does not roll forward to a different major or minor version. It does not accept a prerelease SDK. The agent must have a released 10.0 SDK.
+
+Run both commands with the clone root as the working directory. The `dotnet` muxer searches for `global.json` from the current working directory upward, and not from the project directory. A command that starts in a different directory can select a different SDK, or find no SDK at all.
+
+#### Restore and build
+
+```
+dotnet restore ./test/TestAmqpBroker/TestAmqpBroker.csproj --configfile ./nuget.cfsclean.config
+dotnet build ./test/TestAmqpBroker/TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
 ```
 
-SDK pipeline setup should use the same two commands after `NuGetAuthenticate@1`. Keep the clone unchanged and pass `--configfile` on the restore. Normal developer builds continue to use the root `nuget.config` and its NuGet.org source.
+The paths use forward slashes. The dotnet CLI accepts forward slashes on Windows, Linux, and macOS.
+
+#### Restore scope
+
+`TestAmqpBroker` targets `net48;net10.0`. The restore resolves both frameworks, but the build makes only `net10.0`. Keep this difference.
+
+Do not try to narrow the restore to one framework. `dotnet restore` has no option for a single target framework. A global property such as `-p:TargetFramework=net10.0` is not a substitute. The property flows into the `netstandard2.0` project reference `src/Microsoft.Azure.Amqp.csproj`. That project then writes an assets file with no `netstandard2.0` target, and the build fails with error `NETSDK1005`.
+
+The `net48` half of the restore adds only reference-assembly packages. Those packages are platform independent, so this restore also succeeds on a Linux agent.
+
+#### Build output
+
+The broker project sets `OutputPath` to `bin/$(Configuration)/$(MSBuildProjectName)/`, relative to the clone root. The project is multi-targeted, and this repository has no `Directory.Build.props` or `Directory.Build.targets`, so MSBuild appends the target framework to the output path. The commands above write the broker to this path, relative to the clone root:
+
+```
+bin/Debug/TestAmqpBroker/net10.0/TestAmqpBroker.dll
+```
+
+A consumer that starts the broker must use that path. The same directory also holds a native `TestAmqpBroker` host executable.
+
+#### Feed access and authentication
+
+The `azure-sdk-for-net` feed answers anonymous reads. The feed already holds every package that this restore needs, so the restore succeeds on an agent with no credentials.
+
+Authentication is necessary only for a cache miss. The feed fetches a package from its NuGet.org upstream only for an authenticated request. Azure DevOps pipelines must therefore run `NuGetAuthenticate@1` before the restore. A new or changed dependency then restores correctly, and the agent stays isolated from NuGet.org.
+
+Normal developer builds do not use this config. They continue to use the root `nuget.config` and its NuGet.org source.
+
+#### No coverage in this repository
+
+No pipeline in this repository uses `nuget.cfsclean.config`. A change to the broker's dependencies can therefore break CFSClean restores with no signal here. The failure appears in the downstream Azure SDK repositories instead.

--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,18 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 ```
 dotnet build -p:Version=3.0.0 src\Microsoft.Azure.Amqp.csproj
 ```
+
+### CFSClean test broker build
+
+Azure SDK pipelines running on CFSClean agents must restore `TestAmqpBroker` with the checked-in `nuget.cfsclean.config`. The config clears inherited package sources and uses the public `azure-sdk-for-net` Azure Artifacts feed, which has a NuGet.org upstream.
+
+Azure DevOps pipelines must run `NuGetAuthenticate@1` before the restore. Authentication allows the feed to serve upstream cache misses while the agent remains isolated from NuGet.org.
+
+Run these commands from the root of a pinned `azure-amqp` clone:
+
+```powershell
+dotnet restore .\test\TestAmqpBroker\TestAmqpBroker.csproj --configfile .\nuget.cfsclean.config
+dotnet build .\test\TestAmqpBroker\TestAmqpBroker.csproj --configuration Debug --framework net10.0 --no-restore
+```
+
+SDK pipeline setup should use the same two commands after `NuGetAuthenticate@1`. Keep the clone unchanged and pass `--configfile` on the restore. Normal developer builds continue to use the root `nuget.config` and its NuGet.org source.

--- a/readme.md
+++ b/readme.md
@@ -26,13 +26,9 @@ Downstream repositories clone this repository at a pinned commit and follow this
 
 #### Package source names
 
-The root `nuget.config` names the NuGet.org source `nuget.org`. Keep that name.
+The root `nuget.config` names the NuGet.org source `nuget.org`. Keep that name and its case, and do not add a second source that repeats the NuGet.org URL.
 
-A restricted agent turns off NuGet.org through a `disabledPackageSources` entry, and that entry matches a source by name and not by URL. The match needs the exact string, and it is case sensitive. A source that repeats the same URL under any other name is therefore a different source, and the agent policy does not turn it off. This file used the name `NuGet official package source` until [#318](https://github.com/Azure/azure-amqp/pull/318), so a restore on a restricted agent reached NuGet.org directly and the agent policy had no effect.
-
-Do not rename this source, do not change its case, and do not add a second source that repeats the NuGet.org URL.
-
-Two limits are worth knowing. A NuGet configuration cannot stop a build from reaching NuGet.org; only the network can. This name rule makes the repository cooperate with the agent policy, and it is not a boundary. The `dotnet-public` source also stays on, and the policy does not turn it off, so package traffic can still go to that feed.
+A machine policy can turn off NuGet.org with a `disabledPackageSources` entry, and that entry matches a source by exact name and not by URL. A source that repeats the same URL under another name is a different source, and the policy leaves it on. This file used the name `NuGet official package source` until [#318](https://github.com/Azure/azure-amqp/pull/318), so a restore on a machine with such a policy reached NuGet.org directly. A NuGet configuration cannot block NuGet.org on its own, so this rule lets the repository cooperate with a policy and is not a boundary.
 
 #### .NET SDK requirement
 

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,11 @@ Downstream repositories clone this repository at a pinned commit and follow this
 
 The root `nuget.config` names the NuGet.org source `nuget.org`. Keep that name.
 
-A restricted agent turns off NuGet.org through a `disabledPackageSources` entry, and that entry matches a source by name and not by URL. A source that repeats the same URL under a different name is therefore a different source, and the agent policy does not turn it off. This file used the name `NuGet official package source` until [#318](https://github.com/Azure/azure-amqp/pull/318), so a restore on a restricted agent reached NuGet.org directly and the agent policy had no effect.
+A restricted agent turns off NuGet.org through a `disabledPackageSources` entry, and that entry matches a source by name and not by URL. The match needs the exact string, and it is case sensitive. A source that repeats the same URL under any other name is therefore a different source, and the agent policy does not turn it off. This file used the name `NuGet official package source` until [#318](https://github.com/Azure/azure-amqp/pull/318), so a restore on a restricted agent reached NuGet.org directly and the agent policy had no effect.
 
-Do not rename this source, and do not add a second source that repeats the NuGet.org URL.
+Do not rename this source, do not change its case, and do not add a second source that repeats the NuGet.org URL.
+
+Two limits are worth knowing. A NuGet configuration cannot stop a build from reaching NuGet.org; only the network can. This name rule makes the repository cooperate with the agent policy, and it is not a boundary. The `dotnet-public` source also stays on, and the policy does not turn it off, so package traffic can still go to that feed.
 
 #### .NET SDK requirement
 


### PR DESCRIPTION
## Summary

Fixes a package source name that lets a restore bypass a machine policy, and documents how to build `TestAmqpBroker` from a clone.

## Motivation

A machine policy can turn off NuGet.org with a `disabledPackageSources` entry, and that entry matches a source by exact name and not by URL. The root `nuget.config` named its NuGet.org source `NuGet official package source`, so a machine with such a policy saw a different source that repeated the same URL, left it on, and restored from NuGet.org directly. The Azure SDK pipeline agents carry no such policy, so this does not affect them. A developer machine that carries one is affected.

Two Azure SDK repositories clone this repository and build the broker for their AMQP tests. Both had to work out build facts that no document here stated, and both got some of them wrong. Those repositories now carry their own restore configuration, because a feed policy belongs with the pipeline that enforces it.

Work item: [39130334](https://dev.azure.com/azure-sdk/internal/_workitems/edit/39130334)

## Changes

- Names the NuGet.org source `nuget.org` in the root `nuget.config`, so a `disabledPackageSources` entry matches it. One line, and it changes nothing on a machine with no such policy.
- Documents the broker build in `readme.md`: the build output path, the .NET SDK requirement, the working directory rule for `global.json`, and the reason the restore covers more target frameworks than the build.
- Adds `nuget.cfsclean.config`. The consuming repositories now hold their own copy, so this file is no longer required and can be dropped from this pull request.

## Validation

- On a machine with a `disabledPackageSources` policy, a full solution restore with empty caches made 159 requests to api.nuget.org under the old source name, and 0 under the new name, with exit code 0.
- With no policy present, `nuget.org` stays on and the full solution restore completes. The rename costs a normal machine and the GitHub Actions build nothing.
- A `global.json` that demands an absent SDK, placed in the calling directory, fails the build of a project whose own tree holds a valid one. This makes sure of the documented working directory rule.
- A target framework filter on the restore fails. The property flows into the `netstandard2.0` project reference and raises NU1510, and suppressing that warning moves the failure to NETSDK1005 at build time.
