### PR TITLE
fix(receiver): use bounded windows for size prefetch

### DIFF
--- a/Microsoft.Azure.Amqp/Amqp/AmqpLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/AmqpLink.cs
@@ -347,6 +347,59 @@ namespace Microsoft.Azure.Amqp
             }
         }
 
+        internal bool HasOutstandingCredit
+        {
+            get
+            {
+                lock (this.syncRoot)
+                {
+                    return this.linkCredit > 0 || this.bufferedCredit > 0;
+                }
+            }
+        }
+
+        internal void InitializeLinkCredit(uint credit, bool autoSendFlow)
+        {
+            Fx.Assert(this.State == AmqpObjectState.Start, "Link credit can only be initialized before the link is opened.");
+            lock (this.syncRoot)
+            {
+                this.settings.AutoSendFlow = autoSendFlow;
+                this.settings.TotalLinkCredit = credit;
+                this.linkCredit = credit;
+                this.tempTotalCredit = null;
+                this.bufferedCredit = 0;
+            }
+        }
+
+        internal bool TryIssueCredit(uint credit, bool autoSendFlow, bool drain, ArraySegment<byte> txnId)
+        {
+            bool issueCredit = false;
+            lock (this.syncRoot)
+            {
+                if (this.tempTotalCredit == this.settings.TotalLinkCredit)
+                {
+                    this.tempTotalCredit = null;
+                }
+
+                if (this.linkCredit == 0 &&
+                    this.bufferedCredit == 0 &&
+                    this.tempTotalCredit == null)
+                {
+                    this.settings.AutoSendFlow = autoSendFlow;
+                    this.settings.TotalLinkCredit = credit;
+                    this.linkCredit = credit;
+                    issueCredit = true;
+                }
+            }
+
+            if (issueCredit && credit > 0)
+            {
+                this.SendFlow(false, drain, txnId);
+            }
+
+            return issueCredit;
+        }
+
         public void NotifySessionCredit(int credit)
         {
             if (this.inflightDeliveries != null)

--- a/Microsoft.Azure.Amqp/Amqp/AmqpLinkSettings.cs
+++ b/Microsoft.Azure.Amqp/Amqp/AmqpLinkSettings.cs
@@ -29,6 +29,17 @@ namespace Microsoft.Azure.Amqp
             }
         }
 
+        /// <summary>
+        /// Gets or sets the target size, in bytes, of the local receive cache.
+        /// </summary>
+        /// <remarks>
+        /// This value is a soft prefetch hint, not a strict memory limit. AMQP
+        /// link credit authorizes messages by count rather than by byte size, so
+        /// messages already authorized by an active credit window are accepted
+        /// even when they cause the cache to exceed this target. New credit is
+        /// withheld while the cache is at or above the target. A value of
+        /// <see langword="null"/> disables size-based prefetch.
+        /// </remarks>
         public long? TotalCacheSizeInBytes
         {
             get;

--- a/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
@@ -41,6 +41,14 @@ namespace Microsoft.Azure.Amqp
         {
         }
 
+        /// <summary>
+        /// Gets the target size, in bytes, of the local receive cache.
+        /// </summary>
+        /// <remarks>
+        /// The target is a soft prefetch hint. The cache can temporarily exceed
+        /// it while accepting messages authorized by the current AMQP credit
+        /// window.
+        /// </remarks>
         public long? TotalCacheSizeInBytes
         {
             get
@@ -81,6 +89,23 @@ namespace Microsoft.Azure.Amqp
             }
         }
 
+        /// <summary>
+        /// Sets the target size, in bytes, of the local receive cache.
+        /// </summary>
+        /// <param name="cacheSizeInBytes">
+        /// The soft cache-size target, or <see langword="null"/> to disable
+        /// size-based prefetch.
+        /// </param>
+        /// <remarks>
+        /// Changing the target does not revoke credit already advertised to the
+        /// remote peer. For a finite active credit window, the new target is
+        /// applied when that window completes. An open link with unlimited
+        /// credit remains unchanged until it is recreated because it has no safe
+        /// window boundary. Authorized messages can therefore temporarily cause
+        /// the cache to exceed the target. Size-based prefetch does not apply
+        /// when a message listener is registered because listener delivery does
+        /// not use the local receive cache.
+        /// </remarks>
         public void SetCacheSizeInBytes(long? cacheSizeInBytes)
         {
             lock (this.SyncRoot)
@@ -1095,9 +1120,42 @@ namespace Microsoft.Azure.Amqp
         }
 
         /// <summary>
-        /// Tracks queued message bytes and issues discrete size-based credit windows.
-        /// Queue occupancy controls only future credit and never shrinks active credit.
+        /// Tracks queued message bytes and issues discrete size-based credit
+        /// windows without revoking credit already advertised to the peer.
         /// </summary>
+        /// <remarks>
+        /// Credit is estimated by dividing currently available cache bytes by
+        /// the average serialized size observed in the previous completed
+        /// window. The first window uses a 256-KB estimate, every window is
+        /// limited to 500 messages, and a non-positive target uses one-message
+        /// windows.
+        ///
+        /// An active window is never topped up or reduced. All messages
+        /// authorized by that window are accepted, so the byte target is a soft
+        /// hint and the queue can temporarily overshoot it. A new window is
+        /// issued only after the current window is exhausted, its final delivery
+        /// is complete, and the queue has capacity.
+        ///
+        /// State transitions:
+        ///
+        ///   No active window
+        ///          |
+        ///          v
+        ///   Calculate credit from free bytes / estimated message size
+        ///          |
+        ///          v
+        ///   Issue one bounded window
+        ///          |
+        ///          v
+        ///   Accept all authorized deliveries and collect size samples
+        ///          |
+        ///          v
+        ///   Window exhausted and final fragmented delivery complete
+        ///          |
+        ///          +-- queue at or above target --&gt; pause until dequeue
+        ///          |
+        ///          +-- queue below target --------&gt; issue next window
+        /// </remarks>
         sealed class SizeBasedFlowQueue : Queue<AmqpMessage>
         {
             const long DefaultMessageSizeForCacheSizeCalulation = 256 * 1024;
@@ -1333,6 +1391,9 @@ namespace Microsoft.Azure.Amqp
                     return 1;
                 }
 
+                // Use the previous completed window as the estimate for the next
+                // window. This is deliberately a hint: actual message sizes can
+                // vary, but already-issued credit must not be revoked.
                 long freeBytes = this.targetCacheSizeInBytes - this.queuedBytes;
                 long estimatedSize = this.AverageMessageSizeInBytes;
                 long calculatedCredit = freeBytes / estimatedSize;

--- a/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
@@ -74,13 +74,7 @@ namespace Microsoft.Azure.Amqp
                 SizeBasedFlowQueue queue = this.messageQueue;
                 if (queue != null && queue.IsPrefetchingBySize)
                 {
-                    long totalSize = 0;
-                    if (this.TotalCacheSizeInBytes.HasValue)
-                    {
-                        totalSize = this.TotalCacheSizeInBytes.Value;
-                    }
-
-                    return totalSize - queue.CacheSizeCredit;
+                    return queue.QueuedBytes;
                 }
 
                 return 0;
@@ -89,13 +83,16 @@ namespace Microsoft.Azure.Amqp
 
         public void SetCacheSizeInBytes(long? cacheSizeInBytes)
         {
-            if (cacheSizeInBytes != this.Settings.TotalCacheSizeInBytes)
+            lock (this.SyncRoot)
             {
-                this.Settings.TotalCacheSizeInBytes = cacheSizeInBytes;
-                SizeBasedFlowQueue queue = this.messageQueue;
-                if (queue != null)
+                if (cacheSizeInBytes != this.Settings.TotalCacheSizeInBytes)
                 {
-                    queue.SetLinkCreditUsingTotalCacheSize();
+                    this.Settings.TotalCacheSizeInBytes = cacheSizeInBytes;
+                    SizeBasedFlowQueue queue = this.messageQueue;
+                    if (queue != null && this.messageListener == null)
+                    {
+                        queue.SetCacheSize(cacheSizeInBytes);
+                    }
                 }
             }
         }
@@ -105,6 +102,14 @@ namespace Microsoft.Azure.Amqp
             if (Interlocked.Exchange(ref this.messageListener, messageListener) != null)
             {
                 throw new InvalidOperationException(CommonResources.MessageListenerAlreadyRegistered);
+            }
+
+            lock (this.SyncRoot)
+            {
+                if (this.messageQueue != null && this.messageQueue.IsPrefetchingBySize)
+                {
+                    this.messageQueue.DisableSizeBasedPrefetch();
+                }
             }
         }
 
@@ -225,7 +230,9 @@ namespace Microsoft.Azure.Amqp
                         completeWaiter = false;
 
                         // If no auto-flow, trigger a flow to get messages.
-                        int creditToIssue = this.Settings.AutoSendFlow ? 0 : this.GetOnDemandReceiveCredit();
+                        int creditToIssue = this.Settings.AutoSendFlow || this.messageQueue.IsPrefetchingBySize ?
+                            0 :
+                            this.GetOnDemandReceiveCredit();
                         if (creditToIssue > 0)
                         {
                             // Before the credit is issued, waiters could be completed already. In this case, we will queue the incoming
@@ -244,20 +251,6 @@ namespace Microsoft.Azure.Amqp
             }
 
             return new CompletedAsyncResult<IEnumerable<AmqpMessage>>(messages, callback, state);
-        }
-
-        protected override void OnReceiveStateOpenSent(Attach attach)
-        {
-            // If we uses prefetchBySize logic, then we need to
-            // Update link credit based on Gateway's return max message size
-            lock (this.SyncRoot)
-            {
-                var queue = this.messageQueue as SizeBasedFlowQueue;
-                if (queue != null)
-                {
-                    queue.SetLinkCreditUsingTotalCacheSize();
-                }
-            }
         }
 
         public bool EndReceiveMessages(IAsyncResult result, out IEnumerable<AmqpMessage> messages)
@@ -379,6 +372,14 @@ namespace Microsoft.Azure.Amqp
             else
             {
                 delivery = this.currentMessage = AmqpMessage.CreateReceivedMessage();
+                lock (this.SyncRoot)
+                {
+                    if (this.messageQueue != null)
+                    {
+                        this.messageQueue.OnDeliveryStarted();
+                    }
+                }
+
                 return true;
             }
         }
@@ -388,10 +389,22 @@ namespace Microsoft.Azure.Amqp
             this.messageQueue = new SizeBasedFlowQueue(this);
             this.waiterList = new LinkedList<ReceiveAsyncResult>();
             this.pendingDispositions = new WorkCollection<ArraySegment<byte>, DisposeAsyncResult, DeliveryState>(ByteArrayComparer.Instance);
-            bool syncComplete = base.OpenInternal();
-            if (this.LinkCredit > 0)
+            if (this.messageListener == null && this.Settings.TotalCacheSizeInBytes.HasValue)
             {
-                this.SendFlow(false);
+                this.messageQueue.EnableSizeBasedPrefetch(true);
+            }
+
+            bool syncComplete = base.OpenInternal();
+            lock (this.SyncRoot)
+            {
+                if (this.messageQueue.IsPrefetchingBySize)
+                {
+                    this.messageQueue.TryIssueNextWindow();
+                }
+                else if (this.LinkCredit > 0)
+                {
+                    this.SendFlow(false);
+                }
             }
 
             return syncComplete;
@@ -567,6 +580,14 @@ namespace Microsoft.Azure.Amqp
         {
             if (this.messageListener != null)
             {
+                lock (this.SyncRoot)
+                {
+                    if (this.messageQueue != null && this.messageQueue.IsPrefetchingBySize)
+                    {
+                        this.messageQueue.TrackReceivedMessage(message);
+                    }
+                }
+
                 this.messageListener(message);
             }
             else
@@ -580,24 +601,23 @@ namespace Microsoft.Azure.Amqp
                     {
                         var firstWaiter = this.waiterList.First.Value;
 
-                        if (this.messageQueue.IsPrefetchingBySize)
-                        {
-                            if (this.messageQueue.UpdateCreditToIssue(message))
-                            {
-                                this.SetTotalLinkCredit(this.messageQueue.BoundedTotalLinkCredit, true);
-                            }
-                        }
+                        this.messageQueue.TrackReceivedMessage(message);
 
                         firstWaiter.Add(message);
                         if (firstWaiter.RequestedMessageCount == 1 || firstWaiter.MessageCount >= firstWaiter.RequestedMessageCount)
                         {
                             this.waiterList.RemoveFirst();
                             firstWaiter.OnRemoved();
-                            creditToIssue = this.Settings.AutoSendFlow ? 0 : this.GetOnDemandReceiveCredit();
+                            creditToIssue = this.Settings.AutoSendFlow || this.messageQueue.IsPrefetchingBySize ?
+                                0 :
+                                this.GetOnDemandReceiveCredit();
                             waiter = firstWaiter;
                         }
                     }
-                    else if (!this.Settings.AutoSendFlow && this.Settings.SettleType != SettleMode.SettleOnSend)
+                    else if (this.messageQueue != null &&
+                        !this.Settings.AutoSendFlow &&
+                        !this.messageQueue.IsPrefetchingBySize &&
+                        this.Settings.SettleType != SettleMode.SettleOnSend)
                     {
                         releaseMessage = true;
                     }
@@ -1075,54 +1095,39 @@ namespace Microsoft.Azure.Amqp
         }
 
         /// <summary>
-        /// The different this class from the normal Queue is that
-        /// if we specify a size then we will perform Amqp Flow based on
-        /// the size, where:
-        /// - When en-queuing (cache message from service) we will keep sending credit flow as long as size is not over the cache limit.
-        /// - When de-queuing (return message to user) we will issue flow as soon as the size is below the threshold (70%).
-        /// - When issuing credit we always issue in increment of boundedTotalLinkCredit
-        /// - boundedTotalLinkCredit is based on [total cache size] / [max message size]
-        /// - [total cache size] has a 90% cap to try to prevent overflow - but does not enforce it.
-        /// - we keep updating [max message size] as we receive message in flow.
+        /// Tracks queued message bytes and issues discrete size-based credit windows.
+        /// Queue occupancy controls only future credit and never shrinks active credit.
         /// </summary>
         sealed class SizeBasedFlowQueue : Queue<AmqpMessage>
         {
-            // Basically we stop issuing credit at 90% of queue size, and start again at 50%
-            const double IssueCreditThresholdRatio = 0.5;
-            const double StoppCreditThresholdRatio = 0.9;
             const long DefaultMessageSizeForCacheSizeCalulation = 256 * 1024;
             const uint maxCreditToIssuePerFlow = 500;
             readonly ReceivingAmqpLink receivingLink;
-
-            // the amount of credit that we have, in terms of size. This is used to calculate boundedTotalLinkCredit
-            // Note: think of this as the "free space" that we can still fit message with.
-            long cacheSizeCredit;
-
-            // average message size that gets updated as message flows in. This is used to calculate boundedTotalLinkCredit
-            long inQueueAverageMessageSizeInBytes;
-
-            // the amount of credit in size at which we will start issuing credit again if amount of data is less than this threshold
-            long thresholdCacheSizeInBytes;
-
-            // the amount of credit in size at which we will stop issuing credit to avoid an overflow
-            long overflowBufferCacheSizeInBytes;
-
-            // the actual credit that we issue over the flow. This can be bounded by maxCreditToIssuePerFlow
-            uint boundedTotalLinkCredit;
+            long targetCacheSizeInBytes;
+            long queuedBytes;
+            long estimatedMessageSizeInBytes;
+            long windowMessageBytes;
+            int windowMessageCount;
+            uint issuedWindowSize;
+            uint countBasedTotalLinkCredit;
+            bool countBasedAutoSendFlow;
+            bool isPrefetchingBySize;
+            bool disableSizeBasedPrefetch;
+            bool deliveryInProgress;
 
             public SizeBasedFlowQueue(ReceivingAmqpLink receivingLink)
             {
                 Fx.AssertAndThrow(receivingLink != null, "Receive link should not be null");
                 Fx.AssertAndThrow(receivingLink.Settings != null, "Setting should not be null");
                 this.receivingLink = receivingLink;
-                this.SetLinkCreditUsingTotalCacheSize(true);
+                this.estimatedMessageSizeInBytes = DefaultMessageSizeForCacheSizeCalulation;
             }
 
             internal long AverageMessageSizeInBytes
             {
                 get
                 {
-                    return this.inQueueAverageMessageSizeInBytes > 0 ? this.inQueueAverageMessageSizeInBytes : DefaultMessageSizeForCacheSizeCalulation;
+                    return this.estimatedMessageSizeInBytes;
                 }
             }
 
@@ -1130,7 +1135,7 @@ namespace Microsoft.Azure.Amqp
             {
                 get
                 {
-                    return this.receivingLink.Settings.TotalCacheSizeInBytes.HasValue;
+                    return this.isPrefetchingBySize;
                 }
             }
 
@@ -1138,7 +1143,15 @@ namespace Microsoft.Azure.Amqp
             {
                 get
                 {
-                    return this.cacheSizeCredit;
+                    return this.targetCacheSizeInBytes - this.queuedBytes;
+                }
+            }
+
+            internal long QueuedBytes
+            {
+                get
+                {
+                    return this.queuedBytes;
                 }
             }
 
@@ -1146,138 +1159,193 @@ namespace Microsoft.Azure.Amqp
             {
                 get
                 {
-                    return this.boundedTotalLinkCredit;
+                    return this.issuedWindowSize;
                 }
             }
 
-            public void SetLinkCreditUsingTotalCacheSize(bool setTotalLinkCredit = false)
+            public void EnableSizeBasedPrefetch(bool initializeLinkCredit)
             {
-                if (this.receivingLink.Settings != null && this.IsPrefetchingBySize)
+                Fx.Assert(this.receivingLink.Settings.TotalCacheSizeInBytes.HasValue, "Cache size must be set.");
+                this.countBasedTotalLinkCredit = this.receivingLink.Settings.TotalLinkCredit;
+                this.countBasedAutoSendFlow = this.receivingLink.Settings.AutoSendFlow;
+                this.targetCacheSizeInBytes = this.receivingLink.Settings.TotalCacheSizeInBytes.Value;
+                this.windowMessageBytes = 0;
+                this.windowMessageCount = 0;
+                this.issuedWindowSize = this.receivingLink.LinkCredit;
+                this.disableSizeBasedPrefetch = false;
+                this.isPrefetchingBySize = true;
+
+                if (initializeLinkCredit)
                 {
-                    this.cacheSizeCredit = this.receivingLink.Settings.TotalCacheSizeInBytes ?? 0;
-                    this.thresholdCacheSizeInBytes = (long)(this.cacheSizeCredit * IssueCreditThresholdRatio);
-                    this.overflowBufferCacheSizeInBytes = (long)(this.cacheSizeCredit * (1 - StoppCreditThresholdRatio));
-                    this.boundedTotalLinkCredit = Convert.ToUInt32(this.cacheSizeCredit / this.AverageMessageSizeInBytes);
-                    if (this.boundedTotalLinkCredit <= 0)
-                    {
-                        // safe guard against cacheSizeCredit being set too low.
-                        this.boundedTotalLinkCredit = 1;
-                    }
-
-                    if (this.boundedTotalLinkCredit > maxCreditToIssuePerFlow)
-                    {
-                        this.boundedTotalLinkCredit = maxCreditToIssuePerFlow;
-                    }
-
-                    this.receivingLink.LinkCredit = this.boundedTotalLinkCredit;
-                    if (setTotalLinkCredit)
-                    {
-                        this.receivingLink.Settings.TotalLinkCredit = this.boundedTotalLinkCredit;
-                    }
-
-                    // This will turn on AutoFlow
-                    this.receivingLink.SetTotalLinkCredit(this.boundedTotalLinkCredit, true, true);
+                    this.receivingLink.InitializeLinkCredit(0, false);
+                    this.issuedWindowSize = 0;
                 }
+                else
+                {
+                    this.receivingLink.Settings.AutoSendFlow = false;
+                }
+            }
+
+            public void SetCacheSize(long? cacheSizeInBytes)
+            {
+                if (cacheSizeInBytes.HasValue)
+                {
+                    if (this.IsPrefetchingBySize)
+                    {
+                        this.targetCacheSizeInBytes = cacheSizeInBytes.Value;
+                        this.disableSizeBasedPrefetch = false;
+                        this.TryIssueNextWindow();
+                    }
+                    else
+                    {
+                        // Unlimited credit has no safe window boundary at which it can be revoked.
+                        // Keep the current link unchanged; the setting will apply when a new link opens.
+                        if (this.receivingLink.LinkCredit < uint.MaxValue)
+                        {
+                            this.EnableSizeBasedPrefetch(false);
+                            this.TryIssueNextWindow();
+                        }
+                    }
+                }
+                else if (this.IsPrefetchingBySize)
+                {
+                    this.DisableSizeBasedPrefetch();
+                }
+            }
+
+            public void DisableSizeBasedPrefetch()
+            {
+                this.disableSizeBasedPrefetch = true;
+                this.TryIssueNextWindow();
             }
 
             public new void Enqueue(AmqpMessage amqpMessage)
             {
-                if (amqpMessage != null)
+                if (amqpMessage == null)
                 {
-                    base.Enqueue(amqpMessage);
-                    if (this.IsPrefetchingBySize)
-                    {
-                        this.cacheSizeCredit -= amqpMessage.SerializedMessageSize;
-                        bool issueCredit = false;
-                        if (this.cacheSizeCredit > 0 && this.cacheSizeCredit > this.overflowBufferCacheSizeInBytes)
-                        {
-                            issueCredit = this.UpdateCreditToIssue();
-                        }
-                        else if (this.cacheSizeCredit <= 0)
-                        {
-                            issueCredit = this.boundedTotalLinkCredit != 0;
-                            this.boundedTotalLinkCredit = 0;
-                        }
-                        else
-                        {
-                            issueCredit = this.boundedTotalLinkCredit != 1;
-                            this.boundedTotalLinkCredit = 1;
-                        }
-
-                        if (issueCredit)
-                        {
-                            this.receivingLink.SetTotalLinkCredit(this.boundedTotalLinkCredit, true);
-                        }
-                    }
+                    return;
                 }
+
+                base.Enqueue(amqpMessage);
+                this.queuedBytes += amqpMessage.SerializedMessageSize;
+                this.TrackReceivedMessage(amqpMessage);
             }
 
             public new AmqpMessage Dequeue()
             {
-                var amqpMessage = base.Dequeue();
-                if (amqpMessage != null && this.IsPrefetchingBySize)
+                AmqpMessage amqpMessage = base.Dequeue();
+                if (amqpMessage != null)
                 {
-                    // if we are draining the cache (i.e. receiving) we should start giving
-                    // credit if we now have credit above the threshold.
-                    this.cacheSizeCredit += amqpMessage.SerializedMessageSize;
-
-                    bool issueCredit = false;
-                    if (this.cacheSizeCredit >= this.thresholdCacheSizeInBytes)
-                    {
-                        issueCredit = this.UpdateCreditToIssue();
-                    }
-                    else if (this.cacheSizeCredit > 0)
-                    {
-                        issueCredit = this.boundedTotalLinkCredit != 1;
-                        this.boundedTotalLinkCredit = 1;
-                    }
-
-                    if (issueCredit)
-                    {
-                        this.receivingLink.SetTotalLinkCredit(this.boundedTotalLinkCredit, true);
-                    }
+                    this.queuedBytes -= amqpMessage.SerializedMessageSize;
+                    Fx.Assert(this.queuedBytes >= 0, "Queued message size cannot be negative.");
+                    this.TryIssueNextWindow();
                 }
 
                 return amqpMessage;
             }
 
-            /// <summary>
-            /// This method updates the credit that we will send to service to fetch more
-            /// data based on the current average message size. Only call this method if
-            /// we already check and cache credit is within range (&gt; 0%, &lt; 90%).
-            /// </summary>
-            internal bool UpdateCreditToIssue(AmqpMessage externalMessage = null)
+            public void TrackReceivedMessage(AmqpMessage amqpMessage)
             {
-                var previousCredit = this.boundedTotalLinkCredit;
-                long totalSize = this.receivingLink.Settings.TotalCacheSizeInBytes ?? 0;
-                long externalMessageSize = externalMessage == null ? 0 : externalMessage.SerializedMessageSize;
-                int count = externalMessage == null ? this.Count : this.Count + 1;
-                if (count > 0)
+                if (!this.IsPrefetchingBySize || amqpMessage == null)
                 {
-                    this.inQueueAverageMessageSizeInBytes = (totalSize - (this.cacheSizeCredit - externalMessageSize)) / count;
-                    if (this.inQueueAverageMessageSizeInBytes <= 0)
+                    return;
+                }
+
+                this.windowMessageBytes += amqpMessage.SerializedMessageSize;
+                ++this.windowMessageCount;
+                this.deliveryInProgress = false;
+                if (!this.receivingLink.HasOutstandingCredit)
+                {
+                    this.CompleteWindow();
+                    this.TryIssueNextWindow();
+                }
+            }
+
+            public void OnDeliveryStarted()
+            {
+                if (this.IsPrefetchingBySize)
+                {
+                    this.deliveryInProgress = true;
+                }
+            }
+
+            public void TryIssueNextWindow()
+            {
+                if (!this.IsPrefetchingBySize ||
+                    this.deliveryInProgress ||
+                    this.receivingLink.HasOutstandingCredit)
+                {
+                    return;
+                }
+
+                if (this.disableSizeBasedPrefetch)
+                {
+                    if (this.receivingLink.TryIssueCredit(
+                        this.countBasedTotalLinkCredit,
+                        this.countBasedAutoSendFlow,
+                        false,
+                        AmqpConstants.NullBinary))
                     {
-                        this.inQueueAverageMessageSizeInBytes = DefaultMessageSizeForCacheSizeCalulation;
+                        this.issuedWindowSize = 0;
+                        this.disableSizeBasedPrefetch = false;
+                        this.isPrefetchingBySize = false;
                     }
+
+                    return;
                 }
 
-                // if cacheSizeCredit is negative that means we are already overflowing.
-                this.boundedTotalLinkCredit = this.cacheSizeCredit > 0 ? Convert.ToUInt32(this.cacheSizeCredit / this.AverageMessageSizeInBytes) : 0;
-                if (this.boundedTotalLinkCredit <= 0 && this.cacheSizeCredit > 0)
+                if (!this.HasFreeCapacity())
                 {
-                    // this condition can only be possible if average message size is larger than the cache credit.
-                    // This is not possible in public stamp as we enforce cache size to be larger than 260k and max message size
-                    // is 256k. However this assumption can be broken - e.g. in private stamp max message size can be 1Mb.
-                    // since technically cache is not full, we set it to 1.
-                    this.boundedTotalLinkCredit = 1;
+                    return;
                 }
 
-                if (this.boundedTotalLinkCredit > maxCreditToIssuePerFlow)
+                uint credit = this.CalculateNextWindow();
+                if (this.receivingLink.TryIssueCredit(credit, false, false, AmqpConstants.NullBinary))
                 {
-                    this.boundedTotalLinkCredit = maxCreditToIssuePerFlow;
+                    this.issuedWindowSize = credit;
+                }
+            }
+
+            void CompleteWindow()
+            {
+                if (this.windowMessageCount > 0)
+                {
+                    long average = this.windowMessageBytes / this.windowMessageCount;
+                    this.estimatedMessageSizeInBytes = average > 0 ? average : DefaultMessageSizeForCacheSizeCalulation;
                 }
 
-                return previousCredit != this.boundedTotalLinkCredit;
+                this.windowMessageBytes = 0;
+                this.windowMessageCount = 0;
+                this.issuedWindowSize = 0;
+            }
+
+            bool HasFreeCapacity()
+            {
+                return this.targetCacheSizeInBytes <= 0 ?
+                    this.queuedBytes == 0 :
+                    this.queuedBytes < this.targetCacheSizeInBytes;
+            }
+
+            uint CalculateNextWindow()
+            {
+                if (this.targetCacheSizeInBytes <= 0)
+                {
+                    return 1;
+                }
+
+                long freeBytes = this.targetCacheSizeInBytes - this.queuedBytes;
+                long estimatedSize = this.AverageMessageSizeInBytes;
+                long calculatedCredit = freeBytes / estimatedSize;
+                if (calculatedCredit <= 0)
+                {
+                    calculatedCredit = 1;
+                }
+                else if (calculatedCredit > maxCreditToIssuePerFlow)
+                {
+                    calculatedCredit = maxCreditToIssuePerFlow;
+                }
+
+                return (uint)calculatedCredit;
             }
         }
     }

--- a/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
+++ b/Microsoft.Azure.Amqp/Amqp/ReceivingAmqpLink.cs
@@ -397,11 +397,15 @@ namespace Microsoft.Azure.Amqp
             else
             {
                 delivery = this.currentMessage = AmqpMessage.CreateReceivedMessage();
-                lock (this.SyncRoot)
+                SizeBasedFlowQueue queue = this.messageQueue;
+                if (queue != null && queue.IsPrefetchingBySize)
                 {
-                    if (this.messageQueue != null)
+                    lock (this.SyncRoot)
                     {
-                        this.messageQueue.OnDeliveryStarted();
+                        if (queue == this.messageQueue && queue.IsPrefetchingBySize)
+                        {
+                            queue.OnDeliveryStarted();
+                        }
                     }
                 }
 
@@ -605,11 +609,15 @@ namespace Microsoft.Azure.Amqp
         {
             if (this.messageListener != null)
             {
-                lock (this.SyncRoot)
+                SizeBasedFlowQueue queue = this.messageQueue;
+                if (queue != null && queue.IsPrefetchingBySize)
                 {
-                    if (this.messageQueue != null && this.messageQueue.IsPrefetchingBySize)
+                    lock (this.SyncRoot)
                     {
-                        this.messageQueue.TrackReceivedMessage(message);
+                        if (queue == this.messageQueue && queue.IsPrefetchingBySize)
+                        {
+                            queue.TrackReceivedMessage(message);
+                        }
                     }
                 }
 
@@ -1169,7 +1177,7 @@ namespace Microsoft.Azure.Amqp
             uint issuedWindowSize;
             uint countBasedTotalLinkCredit;
             bool countBasedAutoSendFlow;
-            bool isPrefetchingBySize;
+            volatile bool isPrefetchingBySize;
             bool disableSizeBasedPrefetch;
             bool deliveryInProgress;
 

--- a/test/TestCases/AmqpLinkTests.cs
+++ b/test/TestCases/AmqpLinkTests.cs
@@ -786,6 +786,214 @@ namespace Test.Microsoft.Azure.Amqp
         }
 
         [Fact]
+        public void AmqpSizePrefetchAcceptsIssuedWindowAndRejectsNextTransfer()
+        {
+            const int InitialWindow = 3;
+            const int DefaultEstimatedMessageSize = 256 * 1024;
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(
+                InitialWindow * DefaultEstimatedMessageSize,
+                10,
+                null,
+                out connection);
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, InitialWindow, DefaultEstimatedMessageSize * InitialWindow);
+
+            Assert.Equal(InitialWindow, GetMessageQueueCount(link));
+            Assert.Equal(0u, link.LinkCredit);
+            Assert.Null(link.TerminalException);
+
+            InjectMessages(link, ref deliveryId, 1, 1);
+
+            AmqpException exception = Assert.IsType<AmqpException>(link.TerminalException);
+            Assert.Equal(AmqpErrorCode.TransferLimitExceeded, exception.Error.Condition);
+            connection.Close();
+        }
+
+        [Fact]
+        public void AmqpSizePrefetchDoesNotOverlapWindowsAndResumesAfterDrain()
+        {
+            const int InitialWindow = 3;
+            const int DefaultEstimatedMessageSize = 256 * 1024;
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(
+                InitialWindow * DefaultEstimatedMessageSize,
+                10,
+                null,
+                out connection);
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 1, 1);
+            Assert.Equal(2u, link.LinkCredit);
+
+            AmqpMessage message = ReceiveWithZeroTimeout(link);
+            Assert.NotNull(message);
+            message.Dispose();
+            Assert.Equal(2u, link.LinkCredit);
+
+            InjectMessages(link, ref deliveryId, 2, InitialWindow * DefaultEstimatedMessageSize);
+            Assert.Equal(0u, link.LinkCredit);
+            Assert.Equal(2, GetMessageQueueCount(link));
+
+            message = ReceiveWithZeroTimeout(link);
+            Assert.NotNull(message);
+            message.Dispose();
+            Assert.Equal(0u, link.LinkCredit);
+
+            message = ReceiveWithZeroTimeout(link);
+            Assert.NotNull(message);
+            message.Dispose();
+            Assert.Equal(1u, link.LinkCredit);
+            connection.Close();
+        }
+
+        [Fact]
+        public void AmqpSizePrefetchWaitsForFragmentedDeliveryBeforeNextWindow()
+        {
+            const int DefaultEstimatedMessageSize = 256 * 1024;
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(
+                2 * DefaultEstimatedMessageSize,
+                10,
+                null,
+                out connection);
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 1, 1024);
+            InjectFragment(link, deliveryId, 1024, true);
+            Assert.Equal(0u, link.LinkCredit);
+
+            AmqpMessage message = ReceiveWithZeroTimeout(link);
+            Assert.NotNull(message);
+            message.Dispose();
+            Assert.Equal(0u, link.LinkCredit);
+
+            InjectFragment(link, deliveryId++, 1024, false);
+            Assert.True(link.LinkCredit > 0);
+            Assert.Equal(1, GetMessageQueueCount(link));
+            connection.Close();
+        }
+
+        [Fact]
+        public void AmqpSizePrefetchAdaptsAtWindowBoundaries()
+        {
+            const int DefaultEstimatedMessageSize = 256 * 1024;
+            const int TargetSize = 4 * DefaultEstimatedMessageSize;
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(TargetSize, 10, null, out connection);
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 4, DefaultEstimatedMessageSize / 2);
+            Assert.Equal(4u, link.LinkCredit);
+
+            DrainQueue(link);
+            Assert.Equal(4u, link.LinkCredit);
+
+            InjectMessages(link, ref deliveryId, 4, DefaultEstimatedMessageSize * 2);
+            Assert.Equal(0u, link.LinkCredit);
+
+            DrainQueueConcurrently(link);
+            Assert.Equal(1u, link.LinkCredit);
+
+            InjectMessages(link, ref deliveryId, 1, DefaultEstimatedMessageSize / 2);
+            Assert.Equal(7u, link.LinkCredit);
+            connection.Close();
+        }
+
+        [Fact]
+        public void AmqpSizePrefetchRuntimeChangesWaitForWindowBoundary()
+        {
+            const int DefaultEstimatedMessageSize = 256 * 1024;
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(null, 3, null, out connection);
+
+            link.SetCacheSizeInBytes(3 * DefaultEstimatedMessageSize);
+            Assert.False(link.Settings.AutoSendFlow);
+            Assert.Equal(3u, link.LinkCredit);
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 1, 1);
+            link.SetCacheSizeInBytes(null);
+            Assert.False(link.Settings.AutoSendFlow);
+            Assert.Equal(2u, link.LinkCredit);
+
+            InjectMessages(link, ref deliveryId, 2, 1);
+            Assert.True(link.Settings.AutoSendFlow);
+            Assert.Equal(3u, link.LinkCredit);
+            connection.Close();
+
+            link = this.OpenTestReceivingLink(2 * DefaultEstimatedMessageSize, 10, null, out connection);
+            deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 1, 1024);
+            link.SetCacheSizeInBytes(4 * DefaultEstimatedMessageSize);
+            Assert.Equal(1u, link.LinkCredit);
+
+            InjectMessages(link, ref deliveryId, 1, 1024);
+            Assert.Equal(500u, link.LinkCredit);
+            connection.Close();
+        }
+
+        [Fact]
+        public void AmqpSizePrefetchZeroTargetUsesSingleMessageWindows()
+        {
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(0, 10, null, out connection);
+
+            Assert.Equal(1u, link.LinkCredit);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.Null(ReceiveWithZeroTimeout(link));
+                Assert.Equal(1u, link.LinkCredit);
+            }
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 1, 512 * 1024);
+            Assert.Equal(0u, link.LinkCredit);
+            Assert.Equal(1, GetMessageQueueCount(link));
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            AmqpMessage message = ReceiveWithZeroTimeout(link);
+            stopwatch.Stop();
+            Assert.NotNull(message);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1));
+            message.Dispose();
+            Assert.Equal(1u, link.LinkCredit);
+            connection.Close();
+        }
+
+        [Fact]
+        public void AmqpSizePrefetchPreservesCountAndListenerModes()
+        {
+            const int DefaultEstimatedMessageSize = 256 * 1024;
+            AmqpConnection connection;
+            ReceivingAmqpLink link = this.OpenTestReceivingLink(null, 7, null, out connection);
+            Assert.True(link.Settings.AutoSendFlow);
+            Assert.Equal(7u, link.LinkCredit);
+            Assert.Null(ReceiveWithZeroTimeout(link));
+            Assert.Equal(7u, link.LinkCredit);
+            connection.Close();
+
+            int received = 0;
+            link = this.OpenTestReceivingLink(1024, 5, message => ++received, out connection);
+            Assert.True(link.Settings.AutoSendFlow);
+            Assert.Equal(5u, link.LinkCredit);
+
+            uint deliveryId = 0;
+            InjectMessages(link, ref deliveryId, 1, 2048);
+            Assert.Equal(1, received);
+            Assert.Equal(0, GetMessageQueueCount(link));
+            Assert.Equal(4u, link.LinkCredit);
+            connection.Close();
+
+            link = this.OpenTestReceivingLink(null, uint.MaxValue, null, out connection);
+            link.SetCacheSizeInBytes(DefaultEstimatedMessageSize);
+            Assert.True(link.Settings.AutoSendFlow);
+            Assert.Equal(uint.MaxValue, link.LinkCredit);
+            connection.Close();
+        }
+
+        [Fact]
         public void AmqpTransferWithFlowControlTest()
         {
             string entity = "AmqpTransferWithFlowControlTest";
@@ -1301,6 +1509,124 @@ namespace Test.Microsoft.Azure.Amqp
             ByteBuffer buffer = new ByteBuffer(1024, true);
             Frm(buffer, channel, command, payload);
             connection.SendBuffers(new ByteBuffer[] { buffer });
+        }
+
+        ReceivingAmqpLink OpenTestReceivingLink(
+            long? cacheSizeInBytes,
+            uint countCredit,
+            Action<AmqpMessage> listener,
+            out AmqpConnection connection)
+        {
+            string queue = "AmqpSizePrefetch-" + Guid.NewGuid().ToString("N");
+            this.broker.AddQueue(queue);
+            connection = AmqpUtils.CreateConnection(this.addressUri, null, false, null, (int)AmqpConstants.DefaultMaxFrameSize);
+            connection.Open();
+
+            AmqpSession session = connection.CreateSession(new AmqpSessionSettings());
+            session.Open();
+
+            AmqpLinkSettings settings = AmqpUtils.GetLinkSettings(false, queue, SettleMode.SettleOnSend);
+            settings.TotalLinkCredit = countCredit;
+            settings.AutoSendFlow = countCredit > 0;
+            settings.TotalCacheSizeInBytes = cacheSizeInBytes;
+            ReceivingAmqpLink link = new ReceivingAmqpLink(session, settings);
+            if (listener != null)
+            {
+                link.RegisterMessageListener(listener);
+            }
+
+            link.Open();
+            return link;
+        }
+
+        static void InjectMessages(ReceivingAmqpLink link, ref uint deliveryId, int count, int payloadSize)
+        {
+            byte[] payload = new byte[payloadSize];
+            for (int i = 0; i < count; ++i)
+            {
+                uint currentDeliveryId = deliveryId++;
+                ByteBuffer buffer = new ByteBuffer(payloadSize + 256, true);
+                Frm(
+                    buffer,
+                    0,
+                    Cmd(
+                        Transfer.Code,
+                        0u,
+                        currentDeliveryId,
+                        new ArraySegment<byte>(BitConverter.GetBytes(currentDeliveryId)),
+                        0u,
+                        true),
+                    new ArraySegment<byte>(payload));
+                link.ProcessFrame(Frm(buffer));
+            }
+        }
+
+        static void InjectFragment(ReceivingAmqpLink link, uint deliveryId, int payloadSize, bool more)
+        {
+            ByteBuffer buffer = new ByteBuffer(payloadSize + 256, true);
+            object[] transferFields = more ?
+                new object[]
+                {
+                    0u,
+                    deliveryId,
+                    new ArraySegment<byte>(BitConverter.GetBytes(deliveryId)),
+                    0u,
+                    true,
+                    true
+                } :
+                new object[]
+                {
+                    0u,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false
+                };
+            Frm(
+                buffer,
+                0,
+                Cmd(Transfer.Code, transferFields),
+                new ArraySegment<byte>(new byte[payloadSize]));
+            link.ProcessFrame(Frm(buffer));
+        }
+
+        static AmqpMessage ReceiveWithZeroTimeout(ReceivingAmqpLink link)
+        {
+            AmqpMessage message;
+            link.EndReceiveMessage(link.BeginReceiveMessage(TimeSpan.Zero, null, null), out message);
+            return message;
+        }
+
+        static int GetMessageQueueCount(ReceivingAmqpLink link)
+        {
+            FieldInfo messageQueue = typeof(ReceivingAmqpLink).GetField("messageQueue", BindingFlags.NonPublic | BindingFlags.Instance);
+            var queue = (Queue<AmqpMessage>)messageQueue.GetValue(link);
+            return queue.Count;
+        }
+
+        static void DrainQueue(ReceivingAmqpLink link)
+        {
+            while (GetMessageQueueCount(link) > 0)
+            {
+                AmqpMessage message = ReceiveWithZeroTimeout(link);
+                Assert.NotNull(message);
+                message.Dispose();
+            }
+        }
+
+        static void DrainQueueConcurrently(ReceivingAmqpLink link)
+        {
+            int messageCount = GetMessageQueueCount(link);
+            Task<AmqpMessage>[] receiveTasks = Enumerable.Range(0, messageCount)
+                .Select(_ => Task.Run(() => ReceiveWithZeroTimeout(link)))
+                .ToArray();
+            Task.WaitAll(receiveTasks);
+            foreach (Task<AmqpMessage> receiveTask in receiveTasks)
+            {
+                Assert.NotNull(receiveTask.Result);
+                receiveTask.Result.Dispose();
+            }
         }
 
         static void PipeLineSend(string host, int port, string queue, byte[] message)


### PR DESCRIPTION
## Title

`fix(receiver): use bounded windows for size prefetch`

## Summary

Treat `PrefetchSizeInBytes` as a soft queue-size hint without revoking AMQP
credit already advertised to the service.

The 2.7.x implementation recalculated and reduced link credit as messages entered
and left the local queue. Under rapid zero-timeout receives, those FLOW updates
could overlap an in-flight broker consume and expose a service-side credit
accounting race. The service could then transfer beyond the client's advertised
delivery boundary, causing `amqp:link:transfer-limit-exceeded` and repeated link
recreation.

## Solution

- Replace continuous size-driven credit resizing with discrete manual credit
  windows.
- Never shrink an active credit window.
- Accept and queue every transfer authorized by the current window, even when
  the byte target is temporarily exceeded.
- Pause new credit while the queue is at or above the byte target.
- Calculate the next window from available bytes and the observed average
  serialized message size.
- Wait for the final credited delivery to fully complete, including fragmented
  transfers, before issuing another window.
- Preserve count-based prefetch, listener mode, zero-byte compatibility, and
  genuine transfer-limit enforcement.
- Leave an already-open unlimited-credit link unchanged because it has no safe
  boundary at which credit can be revoked; the size setting applies when the
  link is recreated.

## Tests

Added deterministic coverage for:

- accepting the complete issued window while rejecting the N+1 transfer;
- preventing overlapping windows and resuming after queue drain;
- waiting for fragmented delivery completion before replenishing credit;
- adapting credit estimates at window boundaries;
- applying runtime target changes only at safe boundaries;
- preserving unlimited credit on an already-open link;
- one-message windows for a zero-byte target;
- preserving count-based prefetch and listener behavior.

Validation:

- `netstandard1.3` build passed.
- `netstandard2.0` build passed.
- `net8.0` build passed.
- All 161 `net8.0` tests passed.
- `git diff --check` passed.

## Validation Limitation

The .NET Framework 4.5 target was not built locally because its reference
assemblies are not installed on this machine.

## Local Branch

- Branch: `hotfix/prefetch-size-credit-window`
- Commit: `473d9f5074f1af33e7d77e72669faacd186e416a`
- Base: `origin/hotfix` (`014d7b0`)
- Publication status: local only; not pushed and no remote PR created.
